### PR TITLE
[BB PR #8] Fix *BSD build

### DIFF
--- a/source/common/threading.h
+++ b/source/common/threading.h
@@ -37,6 +37,7 @@
 #include <semaphore.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #endif
 
 #if MACOS


### PR DESCRIPTION
**Migrated from Bitbucket PR #8**
**Author:** Brad Smith
**State:** OPEN
**Created:** 2022-09-11
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/8
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/0brad0/x265_git:976c8b4c9baf%0Dcfee9638c82b?from_pullrequest_id=8&topic=true

---

From OpenBSD, but also seen on FreeBSD.

\[ 63%\] Building CXX object common/CMakeFiles/common.dir/ringmem.cpp.o  
/home/brad/tmp/x265\_git/source/common/ringmem.cpp:163:27: error: use of undeclared identifier 'S\_IRUSR'  
mode\_t mode = S\_IRUSR | S\_IWUSR | S\_IRGRP | S\_IWGRP | S\_IROTH | S\_IWOTH;  
^  
/home/brad/tmp/x265\_git/source/common/ringmem.cpp:163:37: error: use of undeclared identifier 'S\_IWUSR'  
mode\_t mode = S\_IRUSR | S\_IWUSR | S\_IRGRP | S\_IWGRP | S\_IROTH | S\_IWOTH;  
^  
/home/brad/tmp/x265\_git/source/common/ringmem.cpp:163:47: error: use of undeclared identifier 'S\_IRGRP'  
mode\_t mode = S\_IRUSR | S\_IWUSR | S\_IRGRP | S\_IWGRP | S\_IROTH | S\_IWOTH;  
^  
/home/brad/tmp/x265\_git/source/common/ringmem.cpp:163:57: error: use of undeclared identifier 'S\_IWGRP'  
mode\_t mode = S\_IRUSR | S\_IWUSR | S\_IRGRP | S\_IWGRP | S\_IROTH | S\_IWOTH;  
^  
/home/brad/tmp/x265\_git/source/common/ringmem.cpp:163:67: error: use of undeclared identifier 'S\_IROTH'  
mode\_t mode = S\_IRUSR | S\_IWUSR | S\_IRGRP | S\_IWGRP | S\_IROTH | S\_IWOTH;  
^  
/home/brad/tmp/x265\_git/source/common/ringmem.cpp:163:77: error: use of undeclared identifier 'S\_IWOTH'  
mode\_t mode = S\_IRUSR | S\_IWUSR | S\_IRGRP | S\_IWGRP | S\_IROTH | S\_IWOTH;  
^  
6 errors generated.