### PR TITLE
[BB PR #13] Ensure x265_entropyStateBits is prefixed by _ on platforms which require it

### DIFF
--- a/source/common/aarch64/asm.S
+++ b/source/common/aarch64/asm.S
@@ -65,6 +65,8 @@
 #   endif
 #endif
 
+#define mangle(name) EXTERN_ASM # name
+
 #ifdef __APPLE__
 .macro endfunc
 ELF .size \name, . - \name

--- a/source/common/aarch64/asm.S
+++ b/source/common/aarch64/asm.S
@@ -28,40 +28,41 @@
 #define PFX2(prefix, name) PFX3(prefix, name)
 #define PFX(name)          PFX2(X265_NS, name)
 
+
 #ifdef __APPLE__
-#define PREFIX 1
+#   define PREFIX 1
 #endif
 
 #ifdef PREFIX
-#define EXTERN_ASM _
-#define HAVE_AS_FUNC 0
+#   define EXTERN_ASM _
+#   define HAVE_AS_FUNC 0
 #elif defined __clang__
-#define EXTERN_ASM
-#define HAVE_AS_FUNC 0
-#define PREFIX 1
+#   define EXTERN_ASM
+#   define HAVE_AS_FUNC 0
+#   define PREFIX 1
 #else
-#define EXTERN_ASM
-#define HAVE_AS_FUNC 1
+#   define EXTERN_ASM
+#   define HAVE_AS_FUNC 1
 #endif
 
 #ifdef __ELF__
-#define ELF
+#   define ELF
 #else
-#ifdef PREFIX
-#define ELF #
-#else
-#define ELF @
-#endif
+#   ifdef PREFIX
+#       define ELF #
+#   else
+#       define ELF @
+#   endif
 #endif
 
 #if HAVE_AS_FUNC
-#define FUNC
+#   define FUNC
 #else
-#ifdef PREFIX
-#define FUNC #
-#else
-#define FUNC @
-#endif
+#   ifdef PREFIX
+#       define FUNC #
+#   else
+#       define FUNC @
+#   endif
 #endif
 
 #ifdef __APPLE__

--- a/source/common/aarch64/pixel-util.S
+++ b/source/common/aarch64/pixel-util.S
@@ -2407,7 +2407,7 @@ function PFX(costCoeffNxN_neon)
     // x5 - scanFlagMask
     // x6 - baseCtx
     mov             x0, #0
-    movrel          x1, x265_entropyStateBits
+    movrel          x1, mangle(x265_entropyStateBits)
     mov             x4, #0
     mov             x11, #0
     movi            v31.16b, #0


### PR DESCRIPTION
**Migrated from Bitbucket PR #13**
**Author:** kexik
**State:** DECLINED
**Created:** 2023-03-05
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/13
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/kexik/x265_git:280e86b82e18%0D34532bda12a3?from_pullrequest_id=13&topic=true

---

* Make preprocessor conditions easier to read

This just adds indentation to #if/#elseif/#else to make it easier to read without changing actual conditions.

* Introduce mangle\(\) macro to prefix symbols with \_ where required

Without this patch, the following error happens on MacOS arm64:

```
Undefined symbols for architecture arm64:
  "x265_entropyStateBits", referenced from:
      _x265_costCoeffNxN_neon in pixel-util.S.o
     (maybe you meant: _x265_entropyStateBits)
```

The defined macro `mangle(name)` causes the provided argument name to be prefixed with already-defined `EXTERN_ASM` which should hopefully fix the problem in a clean, portable way.

‌