### PR TITLE
[BB PR #15] SVE/SVE2 support for Aarch64 architectures

### DIFF
--- a/.migration-bb-pr-15.md
+++ b/.migration-bb-pr-15.md
@@ -1,0 +1,20 @@
+# Migrated from Bitbucket PR #15
+
+**Title:** SVE/SVE2 support for Aarch64 architectures
+**Author:** David.Chen
+**State:** MERGED
+**Created:** 2023-05-08
+**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/15
+**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/multicoreware/x265_git:604acc6ae093%0Da05d9f5f7f4b?from_pullrequest_id=15&topic=true
+
+## Description
+
+Update ASM code to support SVE/SVE2 instruction set for Aarch64 architectures
+
+The aim of this pull request is to improve x265 performance by using SVE/SVE2 instruction set of Aarch64 architectures.
+
+Only the parts of the code whose migration to SVE/SVE2 improves the performance were considered. For the rest, NEON instruction set is still being used. For the complete list of methods that have been migrated to SVE/SVE2, please check the “source/common/aarch64/asm-primitives.cpp“ file.
+
+It should be noted that only the ASM code has been migrated. Not the C/C\+\+ intrinsics. Also, the needed adaptations were applied in order for the CMAKE to recognize whether the underlying platform supports SVE/SVE2 instruction set and activate SVE or SVE and SVE2 functions accordingly. Finally, README files have been updated accordingly.
+
+All unit and regression tests pass.


### PR DESCRIPTION
**Migrated from Bitbucket PR #15**
**Author:** David.Chen
**State:** MERGED
**Created:** 2023-05-08
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/15
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/multicoreware/x265_git:604acc6ae093%0Da05d9f5f7f4b?from_pullrequest_id=15&topic=true

> **Note:** Source fork inaccessible. Dummy commit used.

---

Update ASM code to support SVE/SVE2 instruction set for Aarch64 architectures

The aim of this pull request is to improve x265 performance by using SVE/SVE2 instruction set of Aarch64 architectures.

Only the parts of the code whose migration to SVE/SVE2 improves the performance were considered. For the rest, NEON instruction set is still being used. For the complete list of methods that have been migrated to SVE/SVE2, please check the “source/common/aarch64/asm-primitives.cpp“ file.

It should be noted that only the ASM code has been migrated. Not the C/C\+\+ intrinsics. Also, the needed adaptations were applied in order for the CMAKE to recognize whether the underlying platform supports SVE/SVE2 instruction set and activate SVE or SVE and SVE2 functions accordingly. Finally, README files have been updated accordingly.

All unit and regression tests pass.