### PR TITLE
[BB PR #18] Fix downversioning of _WIN32_WINNT

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -22,6 +22,7 @@ include(CheckIncludeFiles)
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 include(CheckCXXCompilerFlag)
+include(CheckCSourceCompiles)
 
 option(FPROFILE_GENERATE "Compile executable to generate usage data" OFF)
 option(FPROFILE_USE "Compile executable using generated usage data" OFF)
@@ -486,8 +487,11 @@ if(WIN32)
         # intrinsics introduced after XP
         add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WINXP -D_WIN32_WINNT_WIN7=0x0601)
     else(WINXP_SUPPORT)
-        # default to targeting Windows 7 for the NUMA APIs
-        add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WIN7)
+        check_c_source_compiles("#include <windows.h>\n#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x0601\n#error NOPE\n#endif\nint main(void) {return 0;}" COMPILES_WIN7)
+        if(NOT COMPILES_WIN7)
+            # default to targeting Windows 7 for the NUMA APIs
+            add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WIN7)
+        endif()
     endif(WINXP_SUPPORT)
 endif()
 


### PR DESCRIPTION
**Migrated from Bitbucket PR #18**
**Author:** Steve Lhomme
**State:** DECLINED
**Created:** 2023-06-07
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/18
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/robux4_/x265_git:c8d2a2f0095c%0D9e551a994f97?from_pullrequest_id=18&topic=true

---

Forcing the \_WIN32\_WINNT when the environment is already forcing a value results in a lot of warning.

If the user compiles for a higher version of Windows, we don't need to force compilation for Win7.

‌

The default \_WIN32\_WINNT nowadays is Windows 10.