### PR TITLE
[BB PR #32] fix: symbol not defined on not ELF

### DIFF
--- a/.migration-bb-pr-32.md
+++ b/.migration-bb-pr-32.md
@@ -1,0 +1,16 @@
+# Migrated from Bitbucket PR #32
+
+**Title:** fix: symbol not defined on not ELF
+**Author:** Helmut K. C. Tessarek
+**State:** MERGED
+**Created:** 2025-03-17
+**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/32
+**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/multicoreware/x265_git:529b3379826e%0Da1fd812f3fd7?from_pullrequest_id=32&topic=true
+
+## Description
+
+nasm throws errors on macOS, because the format is not ELF.
+
+fixes [https://bitbucket.org/multicoreware/x265_git/issues/978/](https://bitbucket.org/multicoreware/x265_git/issues/978/){: data-inline-card='' }
+
+There’s another part of the code that uses the same `#if`, which means this issue has already been known. I guess the dev that added the commit that broke the build on macOS didn’t know about it.


### PR DESCRIPTION
**Migrated from Bitbucket PR #32**
**Author:** Helmut K. C. Tessarek
**State:** MERGED
**Created:** 2025-03-17
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/32
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/multicoreware/x265_git:529b3379826e%0Da1fd812f3fd7?from_pullrequest_id=32&topic=true

> **Note:** Code already in master. Dummy commit used to preserve PR record.

---

nasm throws errors on macOS, because the format is not ELF.

fixes [https://bitbucket.org/multicoreware/x265_git/issues/978/](https://bitbucket.org/multicoreware/x265_git/issues/978/){: data-inline-card='' }

There’s another part of the code that uses the same `#if`, which means this issue has already been known. I guess the dev that added the commit that broke the build on macOS didn’t know about it.