### PR TITLE
[BB PR #33] json11.cpp: Include cstdint

### DIFF
--- a/source/dynamicHDR10/json11/json11.cpp
+++ b/source/dynamicHDR10/json11/json11.cpp
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <limits>
+#include <cstdint>
 
 #if _MSC_VER
 #pragma warning(disable: 4510) //const member cannot be default initialized


### PR DESCRIPTION
**Migrated from Bitbucket PR #33**
**Author:** Leon Anavi
**State:** OPEN
**Created:** 2025-05-05
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/33
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/lanavi/x265_git:8bf892b626bd%0Dcfee9638c82b?from_pullrequest_id=33&topic=true

---

Fixes:

json11.cpp:101:32: error: 'uint8\_t' does not name a type

This work was sponsored by GOVCERT.LU.

Signed-off-by: Leon Anavi [leon.anavi@konsulko.com](mailto:leon.anavi@konsulko.com)