### PR TITLE
[BB PR #37] pkgconfig: Make all libs public if static build

### DIFF
--- a/.migration-bb-pr-37.md
+++ b/.migration-bb-pr-37.md
@@ -1,0 +1,12 @@
+# Migrated from Bitbucket PR #37
+
+**Title:** pkgconfig: Make all libs public if static build
+**Author:** Rob Hall
+**State:** OPEN
+**Created:** 2025-08-19
+**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/37
+**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/robxnano/x265_git:9a78de495eb1%0Dcfee9638c82b?from_pullrequest_id=37&topic=true
+
+## Description
+
+If x265 is built as a static library, an application which tries to build with it using pkg-config may fail to link correctly as the pc file lists its required libraries in Libraries.private. The application has no way of knowing that it needs to link against these libraries, so the build fails. To fix this, the required libraries should be listed in the public Libraries section if a static build is requested. This is the same approach as used by ffmpeg, x264, and all Meson projects which use the built-in pc file generator.


### PR DESCRIPTION
**Migrated from Bitbucket PR #37**
**Author:** Rob Hall
**State:** OPEN
**Created:** 2025-08-19
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/37
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/robxnano/x265_git:9a78de495eb1%0Dcfee9638c82b?from_pullrequest_id=37&topic=true

> **Note:** Source fork inaccessible. Dummy commit used.

---

If x265 is built as a static library, an application which tries to build with it using pkg-config may fail to link correctly as the pc file lists its required libraries in Libraries.private. The application has no way of knowing that it needs to link against these libraries, so the build fails. To fix this, the required libraries should be listed in the public Libraries section if a static build is requested. This is the same approach as used by ffmpeg, x264, and all Meson projects which use the built-in pc file generator.