### PR TITLE
[BB PR #41] RISCV64: fix garbled characters in the comments

### DIFF
--- a/.migration-bb-pr-41.md
+++ b/.migration-bb-pr-41.md
@@ -1,0 +1,12 @@
+# Migrated from Bitbucket PR #41
+
+**Title:** RISCV64: fix garbled characters in the comments
+**Author:** wuchangsheng
+**State:** DECLINED
+**Created:** 2025-11-14
+**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/41
+**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/wuchangsheng123/x265_git:1accedb163a6%0D9e551a994f97?from_pullrequest_id=41&topic=true
+
+## Description
+
+


### PR DESCRIPTION
**Migrated from Bitbucket PR #41**
**Author:** wuchangsheng
**State:** DECLINED
**Created:** 2025-11-14
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/41
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/wuchangsheng123/x265_git:1accedb163a6%0D9e551a994f97?from_pullrequest_id=41&topic=true

> **Note:** Source commit not found. Dummy commit used.

---

