### PR TITLE
[BB PR #45] CMake: allow -lpthread in the pkg-config file

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1116,7 +1116,7 @@ if(X265_LATEST_TAG OR NOT GIT_FOUND)
     endforeach()
     if(PLIBLIST)
         # blacklist of libraries that should not be in Libs.private
-        list(REMOVE_ITEM PLIBLIST "-lc" "-lpthread" "-lmingwex" "-lmingwthrd"
+        list(REMOVE_ITEM PLIBLIST "-lc" "-lmingwex" "-lmingwthrd"
             "-lmingw32" "-lmoldname" "-lmsvcrt" "-ladvapi32" "-lshell32"
             "-luser32" "-lkernel32")
         string(REPLACE ";" " " PRIVATE_LIBS "${PLIBLIST}")


### PR DESCRIPTION
**Migrated from Bitbucket PR #45**
**Author:** Steve Lhomme
**State:** OPEN
**Created:** 2026-01-27
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/45
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/robux4_/x265_git:54ff18ccdbbc%0Dcfee9638c82b?from_pullrequest_id=45&topic=true

---

If it was used with -lpthread \(instead of a -pthread flag for example\) it should be in the pkg-config file.

It is not coming from `CMAKE_CXX_IMPLICIT_LINK_LIBRARIES` but added in `PLATFORM_LIBS` when necessary.

The cleaner way to use threading library should be with CMake's FindThread [1]() anyway.

---

1. https://cmake.org/cmake/help/latest/module/FindThreads.html [↩]()

‌