### PR TITLE
[BB PR #1] Fixes some URLs

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -2,13 +2,13 @@
 x265 HEVC Encoder
 =================
 
-| **Read:** | Online `documentation <http://x265.readthedocs.org/en/master/>`_ | Developer `wiki <http://bitbucket.org/multicoreware/x265_git/wiki/>`_
+| **Read:** | Online `documentation <https://x265.readthedocs.io/en/master/>`_ | Developer `wiki <https://bitbucket.org/multicoreware/x265_git/wiki/Home>`_
 | **Download:** | `releases <http://ftp.videolan.org/pub/videolan/x265/>`_ 
-| **Interact:** | #x265 on freenode.irc.net | `x265-devel@videolan.org <http://mailman.videolan.org/listinfo/x265-devel>`_ | `Report an issue <https://bitbucket.org/multicoreware/x265/issues?status=new&status=open>`_
+| **Interact:** | #x265 on freenode.irc.net | `x265-devel@videolan.org <https://mailman.videolan.org/listinfo/x265-devel>`_ | `Report an issue <https://bitbucket.org/multicoreware/x265_git/issues?status=new&status=open>`_
 
 `x265 <https://www.videolan.org/developers/x265.html>`_ is an open
 source HEVC encoder. See the developer wiki for instructions for
 downloading and building the source.
 
-x265 is free to use under the `GNU GPL <http://www.gnu.org/licenses/gpl-2.0.html>`_ 
+x265 is free to use under the `GNU GPL <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>`_ 
 and is also available under a commercial `license <http://x265.org>`_ 


### PR DESCRIPTION
**Migrated from Bitbucket PR #1**
**Author:** Shakil Shahadat
**State:** OPEN
**Created:** 2021-01-01
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/1
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/shakil1/x265_git:616351cd1520%0Dcfee9638c82b?from_pullrequest_id=1

---

Fixes some URLs

1. '.org' to '.io' in documentation URL
2. 'http' to 'https' in documentation, wiki & email URLs
3. Redirection issue with wiki & GPL URLs
4. Adds '\_git' to issue URL

‌