### PR TITLE
[BB PR #2] Fixes the documentation URL in x265cli.cpp

### DIFF
--- a/source/x265cli.cpp
+++ b/source/x265cli.cpp
@@ -369,7 +369,7 @@ namespace X265_NS {
 #undef H1
         if (level < X265_LOG_DEBUG)
             printf("\nUse --fullhelp for a full listing (or --log-level full --help)\n");
-        printf("\n\nComplete documentation may be found at http://x265.readthedocs.org/en/default/cli.html\n");
+        printf("\n\nComplete documentation may be found at https://x265.readthedocs.io/en/master/cli.html\n");
         exit(1);
     }
 


### PR DESCRIPTION
**Migrated from Bitbucket PR #2**
**Author:** Shakil Shahadat
**State:** OPEN
**Created:** 2021-01-01
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/2
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/shakil1/x265_git:38335f941301%0Dcfee9638c82b?from_pullrequest_id=2

---

