### PR TITLE
[BB PR #3] Fixes a typo in presets.rst

### DIFF
--- a/doc/reST/presets.rst
+++ b/doc/reST/presets.rst
@@ -109,7 +109,7 @@ after the preset.
 .. Note::
 
 	The *psnr* and *ssim* tune options disable all optimizations that
-	sacrafice metric scores for perceived visual quality (also known as
+	sacrifice metric scores for perceived visual quality (also known as
 	psycho-visual optimizations). By default x265 always tunes for
 	highest perceived visual quality but if one intends to measure an
 	encode using PSNR or SSIM for the purpose of benchmarking, we highly


### PR DESCRIPTION
**Migrated from Bitbucket PR #3**
**Author:** Shakil Shahadat
**State:** OPEN
**Created:** 2021-01-03
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/3
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/shakil1/x265_git-1:152e9ed8202f%0Dcfee9638c82b?from_pullrequest_id=3

---

Fixes a typo in presets.rst

'sacrafice' to 'sacrifice'