### PR TITLE
[BB PR #4] Fix limitReferences default values for presets

### DIFF
--- a/source/common/param.cpp
+++ b/source/common/param.cpp
@@ -194,7 +194,7 @@ void x265_param_default(x265_param* param)
     param->subpelRefine = 2;
     param->searchRange = 57;
     param->maxNumMergeCand = 3;
-    param->limitReferences = 1;
+    param->limitReferences = 3;
     param->limitModes = 0;
     param->bEnableWeightedPred = 1;
     param->bEnableWeightedBiPred = 0;
@@ -438,7 +438,6 @@ int x265_param_default_preset(x265_param* param, const char* preset, const char*
         else if (!strcmp(preset, "veryfast"))
         {
             param->maxNumMergeCand = 2;
-            param->limitReferences = 3;
             param->bIntraInBFrames = 0;
             param->lookaheadDepth = 15;
             param->bFrameAdaptive = 0;
@@ -451,7 +450,6 @@ int x265_param_default_preset(x265_param* param, const char* preset, const char*
         else if (!strcmp(preset, "faster"))
         {
             param->maxNumMergeCand = 2;
-            param->limitReferences = 3;
             param->bIntraInBFrames = 0;
             param->lookaheadDepth = 15;
             param->bFrameAdaptive = 0;
@@ -462,7 +460,6 @@ int x265_param_default_preset(x265_param* param, const char* preset, const char*
         else if (!strcmp(preset, "fast"))
         {
             param->maxNumMergeCand = 2;
-            param->limitReferences = 3;
             param->bEnableEarlySkip = 0;
             param->bIntraInBFrames = 0;
             param->lookaheadDepth = 15;
@@ -477,7 +474,6 @@ int x265_param_default_preset(x265_param* param, const char* preset, const char*
         }
         else if (!strcmp(preset, "slow"))
         {
-            param->limitReferences = 3;
             param->bEnableEarlySkip = 0;
             param->bIntraInBFrames = 0;
             param->bEnableRectInter = 1;
@@ -508,6 +504,7 @@ int x265_param_default_preset(x265_param* param, const char* preset, const char*
             param->maxNumMergeCand = 4;
             param->searchMethod = X265_STAR_SEARCH;
             param->maxNumReferences = 5;
+            param->limitReferences = 1;
             param->limitModes = 1;
             param->lookaheadSlices = 0; // disabled for best quality
             param->limitTU = 4;


### PR DESCRIPTION
**Migrated from Bitbucket PR #4**
**Author:** Dendraspis
**State:** OPEN
**Created:** 2021-01-17
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/4
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/Dendraspis/x265_git:70e6754f9b61%0Dcfee9638c82b?from_pullrequest_id=4

---

Fix limitReferences default values for presets