### PR TITLE
[BB PR #5] Fixes the documentation URL.

### DIFF
--- a/.migration-bb-pr-5.md
+++ b/.migration-bb-pr-5.md
@@ -1,0 +1,12 @@
+# Migrated from Bitbucket PR #5
+
+**Title:** Fixes the documentation URL.
+**Author:** houlei
+**State:** MERGED
+**Created:** 2021-06-03
+**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/5
+**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/multicoreware/x265_git:82786fccce10%0D82786fccce10?from_pullrequest_id=5
+
+## Description
+
+Fixes the documentation URL.


### PR DESCRIPTION
**Migrated from Bitbucket PR #5**
**Author:** houlei
**State:** MERGED
**Created:** 2021-06-03
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/5
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/multicoreware/x265_git:82786fccce10%0D82786fccce10?from_pullrequest_id=5

> **Note:** Source branch unavailable. Dummy commit used.

---

Fixes the documentation URL.