### PR TITLE
[BB PR #6] fix version tagging

### DIFF
--- a/.migration-bb-pr-6.md
+++ b/.migration-bb-pr-6.md
@@ -1,0 +1,12 @@
+# Migrated from Bitbucket PR #6
+
+**Title:** fix version tagging
+**Author:** Patman86
+**State:** OPEN
+**Created:** 2021-10-28
+**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/6
+**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/None?from_pullrequest_id=6
+
+## Description
+
+fix version tagging


### PR DESCRIPTION
**Migrated from Bitbucket PR #6**
**Author:** Patman86
**State:** OPEN
**Created:** 2021-10-28
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/6
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/None?from_pullrequest_id=6

> **Note:** Source branch unavailable. Dummy commit used.

---

fix version tagging