### PR TITLE
[BB PR #9] temporalfilter: fix multibit builds

### DIFF
--- a/source/common/temporalfilter.h
+++ b/source/common/temporalfilter.h
@@ -33,7 +33,7 @@
 #include "yuv.h"
 #include "motion.h"
 
-using namespace X265_NS;
+namespace X265_NS {
 
 const int s_interpolationFilter[16][8] =
 {
@@ -185,4 +185,5 @@ public:
 
 };
 
+}
 #endif


### PR DESCRIPTION
**Migrated from Bitbucket PR #9**
**Author:** Christopher Degawa
**State:** OPEN
**Created:** 2022-10-26
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/9
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/1480c1/x265_git:c0cb74b92fe1%0Dcfee9638c82b?from_pullrequest_id=9&topic=true

---

the contents of temporalfilter.h should have been using namespace X265\_NS \{\} rather than using namespace x265. This was causing the multibit builds to fail due to multiple definitions of the same symbol.

Signed-off-by: Christopher Degawa ccom@randomderp.com