### PR TITLE
[BB PR #10] fix crash when SEI length is variable

### DIFF
--- a/source/encoder/encoder.cpp
+++ b/source/encoder/encoder.cpp
@@ -1103,6 +1103,12 @@ void Encoder::copyUserSEIMessages(Frame *frame, const x265_picture* pic_in)
                 input = seiMsg;
             else
                 input = pic_in->userSEI.payloads[i];
+            
+            if (frame->m_userSEI.payloads[i].payload && (frame->m_userSEI.payloads[i].payloadSize < input.payloadSize))
+            {
+                delete[] frame->m_userSEI.payloads[i].payload;
+                frame->m_userSEI.payloads[i].payload = NULL;
+            }
 
             if (!frame->m_userSEI.payloads[i].payload)
                 frame->m_userSEI.payloads[i].payload = new uint8_t[input.payloadSize];


### PR DESCRIPTION
**Migrated from Bitbucket PR #10**
**Author:** harlanc
**State:** OPEN
**Created:** 2022-12-01
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/10
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/harlancc/x265_git:8454caf458c5%0Dcfee9638c82b?from_pullrequest_id=10&topic=true

---

The program will crash if the SEI length becomes longer because of memory out of bounds. For detailed information refer to [https://trac.ffmpeg.org/ticket/10085#comment:5%3E](https://trac.ffmpeg.org/ticket/10085#comment:5%3E){: data-inline-card='' }  and [https://trac.ffmpeg.org/ticket/9666#comment:1](https://trac.ffmpeg.org/ticket/9666#comment:1){: data-inline-card='' } 

‌