### PR TITLE
[BB PR #17] api: use LoadLibraryExA instead of LoadLibraryA

### DIFF
--- a/source/encoder/api.cpp
+++ b/source/encoder/api.cpp
@@ -1140,10 +1140,10 @@ const x265_api* x265_api_get(int bitDepth)
             g_recursion++;
 
 #if _WIN32
-        HMODULE h = LoadLibraryA(libname);
+        HMODULE h = LoadLibraryExA(libname, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
         if (!h)
         {
-            h = LoadLibraryA(multilibname);
+            h = LoadLibraryExA(multilibname, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
             reqDepth = bitDepth;
         }
         if (h)
@@ -1233,10 +1233,10 @@ const x265_api* x265_api_query(int bitDepth, int apiVersion, int* err)
             g_recursion++;
 
 #if _WIN32
-        HMODULE h = LoadLibraryA(libname);
+        HMODULE h = LoadLibraryExA(libname, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
         if (!h)
         {
-            h = LoadLibraryA(multilibname);
+            h = LoadLibraryExA(multilibname, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
             reqDepth = bitDepth;
         }
         if (h)


### PR DESCRIPTION
**Migrated from Bitbucket PR #17**
**Author:** Steve Lhomme
**State:** OPEN
**Created:** 2023-06-07
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/17
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/robux4_/x265_git:091315b5845f%0Dcfee9638c82b?from_pullrequest_id=17&topic=true

---

They were introduced in XP but only LoadLibraryExA is allowed in Universal Windows Platform 19H1 builds.

Using LOAD\_LIBRARY\_SEARCH\_DEFAULT\_DIRS is equivalent to the behavior of LoadLibraryA.