### PR TITLE
[BB PR #19] Retrieve Lost Code

### DIFF
--- a/.migration-bb-pr-19.md
+++ b/.migration-bb-pr-19.md
@@ -1,0 +1,20 @@
+# Migrated from Bitbucket PR #19
+
+**Title:** Retrieve Lost Code
+**Author:** David.Chen
+**State:** MERGED
+**Created:** 2023-09-09
+**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/19
+**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/multicoreware/x265_git:b020f4601344%0Da55e7566a5be?from_pullrequest_id=19&topic=true
+
+## Description
+
+During the merge of “Merged in SVE2-support“ \(`a55e756`\), some code has been lost. The purpose of this pull request is to retrieve this code. More specifically, the code from the following commits is retrieved:
+
+- Fix build error in MacOS aarch64
+
+  commit 36785eac984d808d69b5221e84db29103d0b8048
+
+- replace ldr pseudo-instruction with adrp\+add.
+
+   commit 38cf1c379b5af08856bb2fdd65f65a1f99384886


### PR DESCRIPTION
**Migrated from Bitbucket PR #19**
**Author:** David.Chen
**State:** MERGED
**Created:** 2023-09-09
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/19
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/multicoreware/x265_git:b020f4601344%0Da55e7566a5be?from_pullrequest_id=19&topic=true

> **Note:** Source fork inaccessible. Dummy commit used.

---

During the merge of “Merged in SVE2-support“ \(`a55e756`\), some code has been lost. The purpose of this pull request is to retrieve this code. More specifically, the code from the following commits is retrieved:

- Fix build error in MacOS aarch64

  commit 36785eac984d808d69b5221e84db29103d0b8048

- replace ldr pseudo-instruction with adrp\+add.

   commit 38cf1c379b5af08856bb2fdd65f65a1f99384886