### PR TITLE
[BB PR #21] Fix constant UUID for SEI Userdata Unregistered

### DIFF
--- a/.migration-bb-pr-21.md
+++ b/.migration-bb-pr-21.md
@@ -1,0 +1,12 @@
+# Migrated from Bitbucket PR #21
+
+**Title:** Fix constant UUID for SEI Userdata Unregistered
+**Author:** Ingo Oppermann
+**State:** DECLINED
+**Created:** 2024-02-29
+**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/21
+**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/None?from_pullrequest_id=21&topic=true
+
+## Description
+
+When adding SEI Userdata Unregistered with x265pic.userSEI and payload type 5 then the first 16 bytes of the provided payload must be an UUID. However the encoder always prepends its own UUID \(x265's identifying GUID\) to the payload, shadowing the payload's individual UUID.


### PR DESCRIPTION
**Migrated from Bitbucket PR #21**
**Author:** Ingo Oppermann
**State:** DECLINED
**Created:** 2024-02-29
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/21
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/None?from_pullrequest_id=21&topic=true

> **Note:** Source branch unavailable. Dummy commit used.

---

When adding SEI Userdata Unregistered with x265pic.userSEI and payload type 5 then the first 16 bytes of the provided payload must be an UUID. However the encoder always prepends its own UUID \(x265's identifying GUID\) to the payload, shadowing the payload's individual UUID.