### PR TITLE
[BB PR #25] Unbounded copy to stack buffer

### DIFF
--- a/source/common/common.cpp
+++ b/source/common/common.cpp
@@ -133,7 +133,7 @@ void general_log(const x265_param* param, const char* caller, int level, const c
     }
 
     if (caller)
-        p += sprintf(buffer, "%-4s [%s]: ", caller, log_level);
+        p += snprintf(buffer, sizeof(buffer), "%-4s [%s]: ", caller, log_level);
     va_list arg;
     va_start(arg, fmt);
     vsnprintf(buffer + p, bufferSize - p, fmt, arg);
@@ -175,7 +175,7 @@ void general_log_file(const x265_param* param, const char* caller, int level, co
     }
 
     if (caller)
-        p += sprintf(buffer, "%-4s [%s]: ", caller, log_level);
+        p += snprintf(buffer, sizeof(buffer), "%-4s [%s]: ", caller, log_level);
     va_list arg;
     va_start(arg, fmt);
     vsnprintf(buffer + p, bufferSize - p, fmt, arg);

--- a/source/common/param.cpp
+++ b/source/common/param.cpp
@@ -2046,7 +2046,7 @@ static void appendtool(x265_param* param, char* buf, size_t size, const char* to
     if (strlen(buf) + strlen(toolstr) + overhead >= size)
     {
         x265_log(param, X265_LOG_INFO, "tools:%s\n", buf);
-        sprintf(buf, " %s", toolstr);
+        snprintf(buf, sizeof(buf), " %s", toolstr);
     }
     else
     {
@@ -2126,7 +2126,7 @@ void x265_print_params(x265_param* param)
     char buf[80] = { 0 };
     char tmp[40];
 #define TOOLOPT(FLAG, STR) if (FLAG) appendtool(param, buf, sizeof(buf), STR);
-#define TOOLVAL(VAL, STR)  if (VAL) { sprintf(tmp, STR, VAL); appendtool(param, buf, sizeof(buf), tmp); }
+#define TOOLVAL(VAL, STR)  if (VAL) { snprintf(tmp, sizeof(tmp), STR, VAL); appendtool(param, buf, sizeof(buf), tmp); }
     TOOLOPT(param->bEnableRectInter, "rect");
     TOOLOPT(param->bEnableAMP, "amp");
     TOOLOPT(param->limitModes, "limit-modes");
@@ -2170,7 +2170,7 @@ void x265_print_params(x265_param* param)
     {
         if (param->deblockingFilterBetaOffset || param->deblockingFilterTCOffset)
         {
-            sprintf(tmp, "deblock(tC=%d:B=%d)", param->deblockingFilterTCOffset, param->deblockingFilterBetaOffset);
+            snprintf(tmp, sizeof(tmp), "deblock(tC=%d:B=%d)", param->deblockingFilterTCOffset, param->deblockingFilterBetaOffset);
             appendtool(param, buf, sizeof(buf), tmp);
         }
         else
@@ -2211,34 +2211,34 @@ char *x265_param2string(x265_param* p, int padx, int pady)
     if (!buf)
         return NULL;
 #define BOOL(param, cliopt) \
-    s += sprintf(s, " %s", (param) ? cliopt : "no-" cliopt);
+    s += snprintf(s, sizeof(s), " %s", (param) ? cliopt : "no-" cliopt);
 
-    s += sprintf(s, "cpuid=%d", p->cpuid);
-    s += sprintf(s, " frame-threads=%d", p->frameNumThreads);
+    s += snprintf(s, sizeof(s), "cpuid=%d", p->cpuid);
+    s += snprintf(s, sizeof(s), " frame-threads=%d", p->frameNumThreads);
     if (p->numaPools)
-        s += sprintf(s, " numa-pools=%s", p->numaPools);
+        s += snprintf(s, sizeof(s), " numa-pools=%s", p->numaPools);
     BOOL(p->bEnableWavefront, "wpp");
     BOOL(p->bDistributeModeAnalysis, "pmode");
     BOOL(p->bDistributeMotionEstimation, "pme");
     BOOL(p->bEnablePsnr, "psnr");
     BOOL(p->bEnableSsim, "ssim");
-    s += sprintf(s, " log-level=%d", p->logLevel);
+    s += snprintf(s, sizeof(s), " log-level=%d", p->logLevel);
     if (p->csvfn)
-        s += sprintf(s, " csv csv-log-level=%d", p->csvLogLevel);
-    s += sprintf(s, " bitdepth=%d", p->internalBitDepth);
-    s += sprintf(s, " input-csp=%d", p->internalCsp);
-    s += sprintf(s, " fps=%u/%u", p->fpsNum, p->fpsDenom);
-    s += sprintf(s, " input-res=%dx%d", p->sourceWidth - padx, p->sourceHeight - pady);
-    s += sprintf(s, " interlace=%d", p->interlaceMode);
-    s += sprintf(s, " total-frames=%d", p->totalFrames);
+        s += snprintf(s, sizeof(s), " csv csv-log-level=%d", p->csvLogLevel);
+    s += snprintf(s, sizeof(s), " bitdepth=%d", p->internalBitDepth);
+    s += snprintf(s, sizeof(s), " input-csp=%d", p->internalCsp);
+    s += snprintf(s, sizeof(s), " fps=%u/%u", p->fpsNum, p->fpsDenom);
+    s += snprintf(s, sizeof(s), " input-res=%dx%d", p->sourceWidth - padx, p->sourceHeight - pady);
+    s += snprintf(s, sizeof(s), " interlace=%d", p->interlaceMode);
+    s += snprintf(s, sizeof(s), " total-frames=%d", p->totalFrames);
     if (p->chunkStart)
-        s += sprintf(s, " chunk-start=%d", p->chunkStart);
+        s += snprintf(s, sizeof(s), " chunk-start=%d", p->chunkStart);
     if (p->chunkEnd)
-        s += sprintf(s, " chunk-end=%d", p->chunkEnd);
-    s += sprintf(s, " level-idc=%d", p->levelIdc);
-    s += sprintf(s, " high-tier=%d", p->bHighTier);
-    s += sprintf(s, " uhd-bd=%d", p->uhdBluray);
-    s += sprintf(s, " ref=%d", p->maxNumReferences);
+        s += snprintf(s, sizeof(s), " chunk-end=%d", p->chunkEnd);
+    s += snprintf(s, sizeof(s), " level-idc=%d", p->levelIdc);
+    s += snprintf(s, sizeof(s), " high-tier=%d", p->bHighTier);
+    s += snprintf(s, sizeof(s), " uhd-bd=%d", p->uhdBluray);
+    s += snprintf(s, sizeof(s), " ref=%d", p->maxNumReferences);
     BOOL(p->bAllowNonConformance, "allow-non-conformance");
     BOOL(p->bRepeatHeaders, "repeat-headers");
     BOOL(p->bAnnexB, "annexb");
@@ -2247,173 +2247,173 @@ char *x265_param2string(x265_param* p, int padx, int pady)
     BOOL(p->bEnableEndOfSequence, "eos");
     BOOL(p->bEmitHRDSEI, "hrd");
     BOOL(p->bEmitInfoSEI, "info");
-    s += sprintf(s, " hash=%d", p->decodedPictureHashSEI);
-    s += sprintf(s, " temporal-layers=%d", p->bEnableTemporalSubLayers);
+    s += snprintf(s, sizeof(s), " hash=%d", p->decodedPictureHashSEI);
+    s += snprintf(s, sizeof(s), " temporal-layers=%d", p->bEnableTemporalSubLayers);
     BOOL(p->bOpenGOP, "open-gop");
-    s += sprintf(s, " min-keyint=%d", p->keyframeMin);
-    s += sprintf(s, " keyint=%d", p->keyframeMax);
-    s += sprintf(s, " gop-lookahead=%d", p->gopLookahead);
-    s += sprintf(s, " bframes=%d", p->bframes);
-    s += sprintf(s, " b-adapt=%d", p->bFrameAdaptive);
+    s += snprintf(s, sizeof(s), " min-keyint=%d", p->keyframeMin);
+    s += snprintf(s, sizeof(s), " keyint=%d", p->keyframeMax);
+    s += snprintf(s, sizeof(s), " gop-lookahead=%d", p->gopLookahead);
+    s += snprintf(s, sizeof(s), " bframes=%d", p->bframes);
+    s += snprintf(s, sizeof(s), " b-adapt=%d", p->bFrameAdaptive);
     BOOL(p->bBPyramid, "b-pyramid");
-    s += sprintf(s, " bframe-bias=%d", p->bFrameBias);
-    s += sprintf(s, " rc-lookahead=%d", p->lookaheadDepth);
-    s += sprintf(s, " lookahead-slices=%d", p->lookaheadSlices);
-    s += sprintf(s, " scenecut=%d", p->scenecutThreshold);
+    s += snprintf(s, sizeof(s), " bframe-bias=%d", p->bFrameBias);
+    s += snprintf(s, sizeof(s), " rc-lookahead=%d", p->lookaheadDepth);
+    s += snprintf(s, sizeof(s), " lookahead-slices=%d", p->lookaheadSlices);
+    s += snprintf(s, sizeof(s), " scenecut=%d", p->scenecutThreshold);
     BOOL(p->bHistBasedSceneCut, "hist-scenecut");
-    s += sprintf(s, " radl=%d", p->radl);
+    s += snprintf(s, sizeof(s), " radl=%d", p->radl);
     BOOL(p->bEnableHRDConcatFlag, "splice");
     BOOL(p->bIntraRefresh, "intra-refresh");
-    s += sprintf(s, " ctu=%d", p->maxCUSize);
-    s += sprintf(s, " min-cu-size=%d", p->minCUSize);
+    s += snprintf(s, sizeof(s), " ctu=%d", p->maxCUSize);
+    s += snprintf(s, sizeof(s), " min-cu-size=%d", p->minCUSize);
     BOOL(p->bEnableRectInter, "rect");
     BOOL(p->bEnableAMP, "amp");
-    s += sprintf(s, " max-tu-size=%d", p->maxTUSize);
-    s += sprintf(s, " tu-inter-depth=%d", p->tuQTMaxInterDepth);
-    s += sprintf(s, " tu-intra-depth=%d", p->tuQTMaxIntraDepth);
-    s += sprintf(s, " limit-tu=%d", p->limitTU);
-    s += sprintf(s, " rdoq-level=%d", p->rdoqLevel);
-    s += sprintf(s, " dynamic-rd=%.2f", p->dynamicRd);
+    s += snprintf(s, sizeof(s), " max-tu-size=%d", p->maxTUSize);
+    s += snprintf(s, sizeof(s), " tu-inter-depth=%d", p->tuQTMaxInterDepth);
+    s += snprintf(s, sizeof(s), " tu-intra-depth=%d", p->tuQTMaxIntraDepth);
+    s += snprintf(s, sizeof(s), " limit-tu=%d", p->limitTU);
+    s += snprintf(s, sizeof(s), " rdoq-level=%d", p->rdoqLevel);
+    s += snprintf(s, sizeof(s), " dynamic-rd=%.2f", p->dynamicRd);
     BOOL(p->bSsimRd, "ssim-rd");
     BOOL(p->bEnableSignHiding, "signhide");
     BOOL(p->bEnableTransformSkip, "tskip");
-    s += sprintf(s, " nr-intra=%d", p->noiseReductionIntra);
-    s += sprintf(s, " nr-inter=%d", p->noiseReductionInter);
+    s += snprintf(s, sizeof(s), " nr-intra=%d", p->noiseReductionIntra);
+    s += snprintf(s, sizeof(s), " nr-inter=%d", p->noiseReductionInter);
     BOOL(p->bEnableConstrainedIntra, "constrained-intra");
     BOOL(p->bEnableStrongIntraSmoothing, "strong-intra-smoothing");
-    s += sprintf(s, " max-merge=%d", p->maxNumMergeCand);
-    s += sprintf(s, " limit-refs=%d", p->limitReferences);
+    s += snprintf(s, sizeof(s), " max-merge=%d", p->maxNumMergeCand);
+    s += snprintf(s, sizeof(s), " limit-refs=%d", p->limitReferences);
     BOOL(p->limitModes, "limit-modes");
-    s += sprintf(s, " me=%d", p->searchMethod);
-    s += sprintf(s, " subme=%d", p->subpelRefine);
-    s += sprintf(s, " merange=%d", p->searchRange);
+    s += snprintf(s, sizeof(s), " me=%d", p->searchMethod);
+    s += snprintf(s, sizeof(s), " subme=%d", p->subpelRefine);
+    s += snprintf(s, sizeof(s), " merange=%d", p->searchRange);
     BOOL(p->bEnableTemporalMvp, "temporal-mvp");
     BOOL(p->bEnableFrameDuplication, "frame-dup");
     if(p->bEnableFrameDuplication)
-        s += sprintf(s, " dup-threshold=%d", p->dupThreshold);
+        s += snprintf(s, sizeof(s), " dup-threshold=%d", p->dupThreshold);
     BOOL(p->bEnableHME, "hme");
     if (p->bEnableHME)
     {
-        s += sprintf(s, " Level 0,1,2=%d,%d,%d", p->hmeSearchMethod[0], p->hmeSearchMethod[1], p->hmeSearchMethod[2]);
-        s += sprintf(s, " merange L0,L1,L2=%d,%d,%d", p->hmeRange[0], p->hmeRange[1], p->hmeRange[2]);
+        s += snprintf(s, sizeof(s), " Level 0,1,2=%d,%d,%d", p->hmeSearchMethod[0], p->hmeSearchMethod[1], p->hmeSearchMethod[2]);
+        s += snprintf(s, sizeof(s), " merange L0,L1,L2=%d,%d,%d", p->hmeRange[0], p->hmeRange[1], p->hmeRange[2]);
     }
     BOOL(p->bEnableWeightedPred, "weightp");
     BOOL(p->bEnableWeightedBiPred, "weightb");
     BOOL(p->bSourceReferenceEstimation, "analyze-src-pics");
     BOOL(p->bEnableLoopFilter, "deblock");
     if (p->bEnableLoopFilter)
-        s += sprintf(s, "=%d:%d", p->deblockingFilterTCOffset, p->deblockingFilterBetaOffset);
+        s += snprintf(s, sizeof(s), "=%d:%d", p->deblockingFilterTCOffset, p->deblockingFilterBetaOffset);
     BOOL(p->bEnableSAO, "sao");
     BOOL(p->bSaoNonDeblocked, "sao-non-deblock");
-    s += sprintf(s, " rd=%d", p->rdLevel);
-    s += sprintf(s, " selective-sao=%d", p->selectiveSAO);
+    s += snprintf(s, sizeof(s), " rd=%d", p->rdLevel);
+    s += snprintf(s, sizeof(s), " selective-sao=%d", p->selectiveSAO);
     BOOL(p->bEnableEarlySkip, "early-skip");
     BOOL(p->recursionSkipMode, "rskip");
     if (p->recursionSkipMode == EDGE_BASED_RSKIP)
-        s += sprintf(s, " rskip-edge-threshold=%f", p->edgeVarThreshold);
+        s += snprintf(s, sizeof(s), " rskip-edge-threshold=%f", p->edgeVarThreshold);
 
     BOOL(p->bEnableFastIntra, "fast-intra");
     BOOL(p->bEnableTSkipFast, "tskip-fast");
     BOOL(p->bCULossless, "cu-lossless");
     BOOL(p->bIntraInBFrames, "b-intra");
     BOOL(p->bEnableSplitRdSkip, "splitrd-skip");
-    s += sprintf(s, " rdpenalty=%d", p->rdPenalty);
-    s += sprintf(s, " psy-rd=%.2f", p->psyRd);
-    s += sprintf(s, " psy-rdoq=%.2f", p->psyRdoq);
+    s += snprintf(s, sizeof(s), " rdpenalty=%d", p->rdPenalty);
+    s += snprintf(s, sizeof(s), " psy-rd=%.2f", p->psyRd);
+    s += snprintf(s, sizeof(s), " psy-rdoq=%.2f", p->psyRdoq);
     BOOL(p->bEnableRdRefine, "rd-refine");
     BOOL(p->bLossless, "lossless");
-    s += sprintf(s, " cbqpoffs=%d", p->cbQpOffset);
-    s += sprintf(s, " crqpoffs=%d", p->crQpOffset);
-    s += sprintf(s, " rc=%s", p->rc.rateControlMode == X265_RC_ABR ? (
+    s += snprintf(s, sizeof(s), " cbqpoffs=%d", p->cbQpOffset);
+    s += snprintf(s, sizeof(s), " crqpoffs=%d", p->crQpOffset);
+    s += snprintf(s, sizeof(s), " rc=%s", p->rc.rateControlMode == X265_RC_ABR ? (
          p->rc.bitrate == p->rc.vbvMaxBitrate ? "cbr" : "abr")
          : p->rc.rateControlMode == X265_RC_CRF ? "crf" : "cqp");
     if (p->rc.rateControlMode == X265_RC_ABR || p->rc.rateControlMode == X265_RC_CRF)
     {
         if (p->rc.rateControlMode == X265_RC_CRF)
-            s += sprintf(s, " crf=%.1f", p->rc.rfConstant);
+            s += snprintf(s, sizeof(s), " crf=%.1f", p->rc.rfConstant);
         else
-            s += sprintf(s, " bitrate=%d", p->rc.bitrate);
-        s += sprintf(s, " qcomp=%.2f qpstep=%d", p->rc.qCompress, p->rc.qpStep);
-        s += sprintf(s, " stats-write=%d", p->rc.bStatWrite);
-        s += sprintf(s, " stats-read=%d", p->rc.bStatRead);
+            s += snprintf(s, sizeof(s), " bitrate=%d", p->rc.bitrate);
+        s += snprintf(s, sizeof(s), " qcomp=%.2f qpstep=%d", p->rc.qCompress, p->rc.qpStep);
+        s += snprintf(s, sizeof(s), " stats-write=%d", p->rc.bStatWrite);
+        s += snprintf(s, sizeof(s), " stats-read=%d", p->rc.bStatRead);
         if (p->rc.bStatRead)
-            s += sprintf(s, " cplxblur=%.1f qblur=%.1f",
+            s += snprintf(s, sizeof(s), " cplxblur=%.1f qblur=%.1f",
             p->rc.complexityBlur, p->rc.qblur);
         if (p->rc.bStatWrite && !p->rc.bStatRead)
             BOOL(p->rc.bEnableSlowFirstPass, "slow-firstpass");
         if (p->rc.vbvBufferSize)
         {
-            s += sprintf(s, " vbv-maxrate=%d vbv-bufsize=%d vbv-init=%.1f min-vbv-fullness=%.1f max-vbv-fullness=%.1f",
+            s += snprintf(s, sizeof(s), " vbv-maxrate=%d vbv-bufsize=%d vbv-init=%.1f min-vbv-fullness=%.1f max-vbv-fullness=%.1f",
                 p->rc.vbvMaxBitrate, p->rc.vbvBufferSize, p->rc.vbvBufferInit, p->minVbvFullness, p->maxVbvFullness);
             if (p->vbvBufferEnd)
-                s += sprintf(s, " vbv-end=%.1f vbv-end-fr-adj=%.1f", p->vbvBufferEnd, p->vbvEndFrameAdjust);
+                s += snprintf(s, sizeof(s), " vbv-end=%.1f vbv-end-fr-adj=%.1f", p->vbvBufferEnd, p->vbvEndFrameAdjust);
             if (p->rc.rateControlMode == X265_RC_CRF)
-                s += sprintf(s, " crf-max=%.1f crf-min=%.1f", p->rc.rfConstantMax, p->rc.rfConstantMin);   
+                s += snprintf(s, sizeof(s), " crf-max=%.1f crf-min=%.1f", p->rc.rfConstantMax, p->rc.rfConstantMin);   
         }
     }
     else if (p->rc.rateControlMode == X265_RC_CQP)
-        s += sprintf(s, " qp=%d", p->rc.qp);
+        s += snprintf(s, sizeof(s), " qp=%d", p->rc.qp);
     if (!(p->rc.rateControlMode == X265_RC_CQP && p->rc.qp == 0))
     {
-        s += sprintf(s, " ipratio=%.2f", p->rc.ipFactor);
+        s += snprintf(s, sizeof(s), " ipratio=%.2f", p->rc.ipFactor);
         if (p->bframes)
-            s += sprintf(s, " pbratio=%.2f", p->rc.pbFactor);
+            s += snprintf(s, sizeof(s), " pbratio=%.2f", p->rc.pbFactor);
     }
-    s += sprintf(s, " aq-mode=%d", p->rc.aqMode);
-    s += sprintf(s, " aq-strength=%.2f", p->rc.aqStrength);
+    s += snprintf(s, sizeof(s), " aq-mode=%d", p->rc.aqMode);
+    s += snprintf(s, sizeof(s), " aq-strength=%.2f", p->rc.aqStrength);
     BOOL(p->rc.cuTree, "cutree");
-    s += sprintf(s, " zone-count=%d", p->rc.zoneCount);
+    s += snprintf(s, sizeof(s), " zone-count=%d", p->rc.zoneCount);
     if (p->rc.zoneCount)
     {
         for (int i = 0; i < p->rc.zoneCount; ++i)
         {
-            s += sprintf(s, " zones: start-frame=%d end-frame=%d",
+            s += snprintf(s, sizeof(s), " zones: start-frame=%d end-frame=%d",
                  p->rc.zones[i].startFrame, p->rc.zones[i].endFrame);
             if (p->rc.zones[i].bForceQp)
-                s += sprintf(s, " qp=%d", p->rc.zones[i].qp);
+                s += snprintf(s, sizeof(s), " qp=%d", p->rc.zones[i].qp);
             else
-                s += sprintf(s, " bitrate-factor=%f", p->rc.zones[i].bitrateFactor);
+                s += snprintf(s, sizeof(s), " bitrate-factor=%f", p->rc.zones[i].bitrateFactor);
         }
     }
     BOOL(p->rc.bStrictCbr, "strict-cbr");
-    s += sprintf(s, " qg-size=%d", p->rc.qgSize);
+    s += snprintf(s, sizeof(s), " qg-size=%d", p->rc.qgSize);
     BOOL(p->rc.bEnableGrain, "rc-grain");
-    s += sprintf(s, " qpmax=%d qpmin=%d", p->rc.qpMax, p->rc.qpMin);
+    s += snprintf(s, sizeof(s), " qpmax=%d qpmin=%d", p->rc.qpMax, p->rc.qpMin);
     BOOL(p->rc.bEnableConstVbv, "const-vbv");
-    s += sprintf(s, " sar=%d", p->vui.aspectRatioIdc);
+    s += snprintf(s, sizeof(s), " sar=%d", p->vui.aspectRatioIdc);
     if (p->vui.aspectRatioIdc == X265_EXTENDED_SAR)
-        s += sprintf(s, " sar-width : sar-height=%d:%d", p->vui.sarWidth, p->vui.sarHeight);
-    s += sprintf(s, " overscan=%d", p->vui.bEnableOverscanInfoPresentFlag);
+        s += snprintf(s, sizeof(s), " sar-width : sar-height=%d:%d", p->vui.sarWidth, p->vui.sarHeight);
+    s += snprintf(s, sizeof(s), " overscan=%d", p->vui.bEnableOverscanInfoPresentFlag);
     if (p->vui.bEnableOverscanInfoPresentFlag)
-        s += sprintf(s, " overscan-crop=%d", p->vui.bEnableOverscanAppropriateFlag);
-    s += sprintf(s, " videoformat=%d", p->vui.videoFormat);
-    s += sprintf(s, " range=%d", p->vui.bEnableVideoFullRangeFlag);
-    s += sprintf(s, " colorprim=%d", p->vui.colorPrimaries);
-    s += sprintf(s, " transfer=%d", p->vui.transferCharacteristics);
-    s += sprintf(s, " colormatrix=%d", p->vui.matrixCoeffs);
-    s += sprintf(s, " chromaloc=%d", p->vui.bEnableChromaLocInfoPresentFlag);
+        s += snprintf(s, sizeof(s), " overscan-crop=%d", p->vui.bEnableOverscanAppropriateFlag);
+    s += snprintf(s, sizeof(s), " videoformat=%d", p->vui.videoFormat);
+    s += snprintf(s, sizeof(s), " range=%d", p->vui.bEnableVideoFullRangeFlag);
+    s += snprintf(s, sizeof(s), " colorprim=%d", p->vui.colorPrimaries);
+    s += snprintf(s, sizeof(s), " transfer=%d", p->vui.transferCharacteristics);
+    s += snprintf(s, sizeof(s), " colormatrix=%d", p->vui.matrixCoeffs);
+    s += snprintf(s, sizeof(s), " chromaloc=%d", p->vui.bEnableChromaLocInfoPresentFlag);
     if (p->vui.bEnableChromaLocInfoPresentFlag)
-        s += sprintf(s, " chromaloc-top=%d chromaloc-bottom=%d",
+        s += snprintf(s, sizeof(s), " chromaloc-top=%d chromaloc-bottom=%d",
         p->vui.chromaSampleLocTypeTopField, p->vui.chromaSampleLocTypeBottomField);
-    s += sprintf(s, " display-window=%d", p->vui.bEnableDefaultDisplayWindowFlag);
+    s += snprintf(s, sizeof(s), " display-window=%d", p->vui.bEnableDefaultDisplayWindowFlag);
     if (p->vui.bEnableDefaultDisplayWindowFlag)
-        s += sprintf(s, " left=%d top=%d right=%d bottom=%d",
+        s += snprintf(s, sizeof(s), " left=%d top=%d right=%d bottom=%d",
         p->vui.defDispWinLeftOffset, p->vui.defDispWinTopOffset,
         p->vui.defDispWinRightOffset, p->vui.defDispWinBottomOffset);
     if (p->masteringDisplayColorVolume)
-        s += sprintf(s, " master-display=%s", p->masteringDisplayColorVolume);
+        s += snprintf(s, sizeof(s), " master-display=%s", p->masteringDisplayColorVolume);
     if (p->bEmitCLL)
-        s += sprintf(s, " cll=%hu,%hu", p->maxCLL, p->maxFALL);
-    s += sprintf(s, " min-luma=%hu", p->minLuma);
-    s += sprintf(s, " max-luma=%hu", p->maxLuma);
-    s += sprintf(s, " log2-max-poc-lsb=%d", p->log2MaxPocLsb);
+        s += snprintf(s, sizeof(s), " cll=%hu,%hu", p->maxCLL, p->maxFALL);
+    s += snprintf(s, sizeof(s), " min-luma=%hu", p->minLuma);
+    s += snprintf(s, sizeof(s), " max-luma=%hu", p->maxLuma);
+    s += snprintf(s, sizeof(s), " log2-max-poc-lsb=%d", p->log2MaxPocLsb);
     BOOL(p->bEmitVUITimingInfo, "vui-timing-info");
     BOOL(p->bEmitVUIHRDInfo, "vui-hrd-info");
-    s += sprintf(s, " slices=%d", p->maxSlices);
+    s += snprintf(s, sizeof(s), " slices=%d", p->maxSlices);
     BOOL(p->bOptQpPPS, "opt-qp-pps");
     BOOL(p->bOptRefListLengthPPS, "opt-ref-list-length-pps");
     BOOL(p->bMultiPassOptRPS, "multi-pass-opt-rps");
-    s += sprintf(s, " scenecut-bias=%.2f", p->scenecutBias);
+    s += snprintf(s, sizeof(s), " scenecut-bias=%.2f", p->scenecutBias);
     BOOL(p->bOptCUDeltaQP, "opt-cu-delta-qp");
     BOOL(p->bAQMotion, "aq-motion");
     BOOL(p->bEmitHDR10SEI, "hdr10");
@@ -2421,39 +2421,39 @@ char *x265_param2string(x265_param* p, int padx, int pady)
     BOOL(p->bDhdr10opt, "dhdr10-opt");
     BOOL(p->bEmitIDRRecoverySEI, "idr-recovery-sei");
     if (p->analysisSave)
-        s += sprintf(s, " analysis-save");
+        s += snprintf(s, sizeof(s), " analysis-save");
     if (p->analysisLoad)
-        s += sprintf(s, " analysis-load");
-    s += sprintf(s, " analysis-reuse-level=%d", p->analysisReuseLevel);
-    s += sprintf(s, " analysis-save-reuse-level=%d", p->analysisSaveReuseLevel);
-    s += sprintf(s, " analysis-load-reuse-level=%d", p->analysisLoadReuseLevel);
-    s += sprintf(s, " scale-factor=%d", p->scaleFactor);
-    s += sprintf(s, " refine-intra=%d", p->intraRefine);
-    s += sprintf(s, " refine-inter=%d", p->interRefine);
-    s += sprintf(s, " refine-mv=%d", p->mvRefine);
-    s += sprintf(s, " refine-ctu-distortion=%d", p->ctuDistortionRefine);
+        s += snprintf(s, sizeof(s), " analysis-load");
+    s += snprintf(s, sizeof(s), " analysis-reuse-level=%d", p->analysisReuseLevel);
+    s += snprintf(s, sizeof(s), " analysis-save-reuse-level=%d", p->analysisSaveReuseLevel);
+    s += snprintf(s, sizeof(s), " analysis-load-reuse-level=%d", p->analysisLoadReuseLevel);
+    s += snprintf(s, sizeof(s), " scale-factor=%d", p->scaleFactor);
+    s += snprintf(s, sizeof(s), " refine-intra=%d", p->intraRefine);
+    s += snprintf(s, sizeof(s), " refine-inter=%d", p->interRefine);
+    s += snprintf(s, sizeof(s), " refine-mv=%d", p->mvRefine);
+    s += snprintf(s, sizeof(s), " refine-ctu-distortion=%d", p->ctuDistortionRefine);
     BOOL(p->bLimitSAO, "limit-sao");
-    s += sprintf(s, " ctu-info=%d", p->bCTUInfo);
+    s += snprintf(s, sizeof(s), " ctu-info=%d", p->bCTUInfo);
     BOOL(p->bLowPassDct, "lowpass-dct");
-    s += sprintf(s, " refine-analysis-type=%d", p->bAnalysisType);
-    s += sprintf(s, " copy-pic=%d", p->bCopyPicToFrame);
-    s += sprintf(s, " max-ausize-factor=%.1f", p->maxAUSizeFactor);
+    s += snprintf(s, sizeof(s), " refine-analysis-type=%d", p->bAnalysisType);
+    s += snprintf(s, sizeof(s), " copy-pic=%d", p->bCopyPicToFrame);
+    s += snprintf(s, sizeof(s), " max-ausize-factor=%.1f", p->maxAUSizeFactor);
     BOOL(p->bDynamicRefine, "dynamic-refine");
     BOOL(p->bSingleSeiNal, "single-sei");
     BOOL(p->rc.hevcAq, "hevc-aq");
     BOOL(p->bEnableSvtHevc, "svt");
     BOOL(p->bField, "field");
-    s += sprintf(s, " qp-adaptation-range=%.2f", p->rc.qpAdaptationRange);
-    s += sprintf(s, " scenecut-aware-qp=%d", p->bEnableSceneCutAwareQp);
+    s += snprintf(s, sizeof(s), " qp-adaptation-range=%.2f", p->rc.qpAdaptationRange);
+    s += snprintf(s, sizeof(s), " scenecut-aware-qp=%d", p->bEnableSceneCutAwareQp);
     if (p->bEnableSceneCutAwareQp)
-        s += sprintf(s, " fwd-scenecut-window=%d fwd-ref-qp-delta=%f fwd-nonref-qp-delta=%f bwd-scenecut-window=%d bwd-ref-qp-delta=%f bwd-nonref-qp-delta=%f", p->fwdMaxScenecutWindow, p->fwdRefQpDelta[0], p->fwdNonRefQpDelta[0], p->bwdMaxScenecutWindow, p->bwdRefQpDelta[0], p->bwdNonRefQpDelta[0]);
-    s += sprintf(s, " conformance-window-offsets right=%d bottom=%d", p->confWinRightOffset, p->confWinBottomOffset);
-    s += sprintf(s, " decoder-max-rate=%d", p->decoderVbvMaxRate);
+        s += snprintf(s, sizeof(s), " fwd-scenecut-window=%d fwd-ref-qp-delta=%f fwd-nonref-qp-delta=%f bwd-scenecut-window=%d bwd-ref-qp-delta=%f bwd-nonref-qp-delta=%f", p->fwdMaxScenecutWindow, p->fwdRefQpDelta[0], p->fwdNonRefQpDelta[0], p->bwdMaxScenecutWindow, p->bwdRefQpDelta[0], p->bwdNonRefQpDelta[0]);
+    s += snprintf(s, sizeof(s), " conformance-window-offsets right=%d bottom=%d", p->confWinRightOffset, p->confWinBottomOffset);
+    s += snprintf(s, sizeof(s), " decoder-max-rate=%d", p->decoderVbvMaxRate);
     BOOL(p->bliveVBV2pass, "vbv-live-multi-pass");
     if (p->filmGrain)
-        s += sprintf(s, " film-grain=%s", p->filmGrain); // Film grain characteristics model filename
+        s += snprintf(s, sizeof(s), " film-grain=%s", p->filmGrain); // Film grain characteristics model filename
     if (p->aomFilmGrain)
-        s += sprintf(s, " aom-film-grain=%s", p->aomFilmGrain);
+        s += snprintf(s, sizeof(s), " aom-film-grain=%s", p->aomFilmGrain);
     BOOL(p->bEnableTemporalFilter, "mcstf");
 #if ENABLE_ALPHA
     BOOL(p->bEnableAlpha, "alpha");

--- a/source/common/primitives.cpp
+++ b/source/common/primitives.cpp
@@ -215,7 +215,7 @@ void x265_report_simd(x265_param* param)
         int cpuid = param->cpuid;
 
         char buf[1000];
-        char *p = buf + sprintf(buf, "using cpu capabilities:");
+        char *p = buf + snprintf(buf, sizeof(buf), "using cpu capabilities:");
         char *none = p;
         for (int i = 0; X265_NS::cpu_names[i].flags; i++)
         {
@@ -236,11 +236,11 @@ void x265_report_simd(x265_param* param)
                 continue;
             if ((cpuid & X265_NS::cpu_names[i].flags) == X265_NS::cpu_names[i].flags
                 && (!i || X265_NS::cpu_names[i].flags != X265_NS::cpu_names[i - 1].flags))
-                p += sprintf(p, " %s", X265_NS::cpu_names[i].name);
+                p += snprintf(p, sizeof(p), " %s", X265_NS::cpu_names[i].name);
         }
 
         if (p == none)
-            sprintf(p, " none!");
+            snprintf(p, sizeof(p), " none!");
         x265_log(param, X265_LOG_INFO, "%s\n", buf);
     }
 }

--- a/source/common/threadpool.cpp
+++ b/source/common/threadpool.cpp
@@ -309,9 +309,9 @@ ThreadPool* ThreadPool::allocThreadPools(x265_param* p, int& numPools, bool isTh
          {
              char nextCount[10] = "";
              if (i)
-                 sprintf(nextCount, ",%d", cpusPerNode[i]);
+                 snprintf(nextCount, sizeof(nextCount), ",%d", cpusPerNode[i]);
              else
-                   sprintf(nextCount, "%d", cpusPerNode[i]);
+                   snprintf(nextCount, sizeof(nextCount), "%d", cpusPerNode[i]);
              strcat(poolString, nextCount);
          }
          x265_param_parse(p, "pools", poolString);
@@ -452,7 +452,7 @@ ThreadPool* ThreadPool::allocThreadPools(x265_param* p, int& numPools, bool isTh
                 int len = 0;
                 for (int j = 0; j < 64; j++)
                     if ((nodeMaskPerPool[node] >> j) & 1)
-                        len += sprintf(nodesstr + len, ",%d", j);
+                        len += snprintf(nodesstr + len, sizeof(nodesstr) - len, ",%d", j);
                 x265_log(p, X265_LOG_INFO, "Thread pool %d using %d threads on numa nodes %s\n", i, numThreads, nodesstr + 1);
                 delete[] nodesstr;
             }

--- a/source/encoder/encoder.cpp
+++ b/source/encoder/encoder.cpp
@@ -295,11 +295,11 @@ void Encoder::create()
     char buf[128];
     int len = 0;
     if (p->bEnableWavefront)
-        len += sprintf(buf + len, "wpp(%d rows)", rows);
+        len += snprintf(buf + len, sizeof(buf) - len, "wpp(%d rows)", rows);
     if (p->bDistributeModeAnalysis)
-        len += sprintf(buf + len, "%spmode", len ? "+" : "");
+        len += snprintf(buf + len,  sizeof(buf) - len, "%spmode", len ? "+" : "");
     if (p->bDistributeMotionEstimation)
-        len += sprintf(buf + len, "%spme ", len ? "+" : "");
+        len += snprintf(buf + len, sizeof(buf) - len, "%spme ", len ? "+" : "");
     if (!len)
         strcpy(buf, "none");
 
@@ -2794,22 +2794,22 @@ char* Encoder::statsString(EncStats& stat, char* buffer)
     double fps = (double)m_param->fpsNum / m_param->fpsDenom;
     double scale = fps / 1000 / (double)stat.m_numPics;
 
-    int len = sprintf(buffer, "%6u, ", stat.m_numPics);
+    int len = snprintf(buffer, sizeof(buffer), "%6u, ", stat.m_numPics);
 
-    len += sprintf(buffer + len, "Avg QP:%2.2lf", stat.m_totalQp / (double)stat.m_numPics);
-    len += sprintf(buffer + len, "  kb/s: %-8.2lf", stat.m_accBits * scale);
+    len += snprintf(buffer + len, sizeof(buffer) - len, "Avg QP:%2.2lf", stat.m_totalQp / (double)stat.m_numPics);
+    len += snprintf(buffer + len, sizeof(buffer) - len, "  kb/s: %-8.2lf", stat.m_accBits * scale);
     if (m_param->bEnablePsnr)
     {
-        len += sprintf(buffer + len, "  PSNR Mean: Y:%.3lf U:%.3lf V:%.3lf",
-                       stat.m_psnrSumY / (double)stat.m_numPics,
-                       stat.m_psnrSumU / (double)stat.m_numPics,
-                       stat.m_psnrSumV / (double)stat.m_numPics);
+        len += snprintf(buffer + len, sizeof(buffer) - len,"  PSNR Mean: Y:%.3lf U:%.3lf V:%.3lf",
+                        stat.m_psnrSumY / (double)stat.m_numPics,
+                        stat.m_psnrSumU / (double)stat.m_numPics,
+                        stat.m_psnrSumV / (double)stat.m_numPics);
     }
     if (m_param->bEnableSsim)
     {
-        sprintf(buffer + len, "  SSIM Mean: %.6lf (%.3lfdB)",
-                stat.m_globalSsim / (double)stat.m_numPics,
-                x265_ssim2dB(stat.m_globalSsim / (double)stat.m_numPics));
+        snprintf(buffer + len, sizeof(buffer) - len, "  SSIM Mean: %.6lf (%.3lfdB)",
+                 stat.m_globalSsim / (double)stat.m_numPics,
+                 x265_ssim2dB(stat.m_globalSsim / (double)stat.m_numPics));
     }
     return buffer;
 }
@@ -2864,19 +2864,19 @@ void Encoder::printSummary()
             double elapsedVideoTime = (double)m_analyzeAll[layer].m_numPics * m_param->fpsDenom / m_param->fpsNum;
             double bitrate = (0.001f * m_analyzeAll[layer].m_accBits) / elapsedVideoTime;
 
-            p += sprintf(buffer + p, "\nencoded %d frames in %.2fs (%.2f fps), %.2f kb/s, Avg QP:%2.2lf", m_analyzeAll[layer].m_numPics,
+            p += snprintf(buffer + p, sizeof(buffer) - p, "\nencoded %d frames in %.2fs (%.2f fps), %.2f kb/s, Avg QP:%2.2lf", m_analyzeAll[layer].m_numPics,
                 elapsedEncodeTime, m_analyzeAll[layer].m_numPics / elapsedEncodeTime, bitrate, m_analyzeAll[layer].m_totalQp / (double)m_analyzeAll[layer].m_numPics);
 
             if (m_param->bEnablePsnr)
             {
                 double globalPsnr = (m_analyzeAll[layer].m_psnrSumY * 6 + m_analyzeAll[layer].m_psnrSumU + m_analyzeAll[layer].m_psnrSumV) / (8 * m_analyzeAll[layer].m_numPics);
-                p += sprintf(buffer + p, ", Global PSNR: %.3f", globalPsnr);
+                p += snprintf(buffer + p, sizeof(buffer) - p, ", Global PSNR: %.3f", globalPsnr);
             }
 
             if (m_param->bEnableSsim)
-                p += sprintf(buffer + p, ", SSIM Mean Y: %.7f (%6.3f dB)", m_analyzeAll[layer].m_globalSsim / m_analyzeAll[layer].m_numPics, x265_ssim2dB(m_analyzeAll[layer].m_globalSsim / m_analyzeAll[layer].m_numPics));
+                p += snprintf(buffer + p, sizeof(buffer) - p, ", SSIM Mean Y: %.7f (%6.3f dB)", m_analyzeAll[layer].m_globalSsim / m_analyzeAll[layer].m_numPics, x265_ssim2dB(m_analyzeAll[layer].m_globalSsim / m_analyzeAll[layer].m_numPics));
 
-            sprintf(buffer + p, "\n");
+            snprintf(buffer + p, sizeof(buffer) - p, "\n");
             general_log(m_param, NULL, X265_LOG_INFO, buffer);
         }
         else
@@ -3448,14 +3448,14 @@ void Encoder::getStreamHeaders(NALList& list, Entropy& sbacCoder, Bitstream& bs)
         char *opts = x265_param2string(m_param, m_sps.conformanceWindow.rightOffset, m_sps.conformanceWindow.bottomOffset);
         if (opts)
         {
-            char *buffer = X265_MALLOC(char, strlen(opts) + strlen(PFX(version_str)) +
-                strlen(PFX(build_info_str)) + 200);
+            int len = strlen(opts) + strlen(PFX(version_str)) + strlen(PFX(build_info_str)) + 200;
+            char *buffer = X265_MALLOC(char, len);
             if (buffer)
             {
-                sprintf(buffer, "x265 (build %d) - %s:%s - H.265/HEVC codec - "
-                    "Copyright 2013-2018 (c) Multicoreware, Inc - "
-                    "http://x265.org - options: %s",
-                    X265_BUILD, PFX(version_str), PFX(build_info_str), opts);
+                snprintf(buffer, len, "x265 (build %d) - %s:%s - H.265/HEVC codec - "
+                         "Copyright 2013-2018 (c) Multicoreware, Inc - "
+                         "http://x265.org - options: %s",
+                         X265_BUILD, PFX(version_str), PFX(build_info_str), opts);
 
                 SEIuserDataUnregistered idsei;
                 idsei.m_userData = (uint8_t*)buffer;
@@ -6209,7 +6209,7 @@ void Encoder::printReconfigureParams()
     x265_log(newParam, X265_LOG_DEBUG, "Reconfigured param options, input Frame: %d\n", m_pocLast + 1);
 
     char tmp[60];
-#define TOOLCMP(COND1, COND2, STR)  if (COND1 != COND2) { sprintf(tmp, STR, COND1, COND2); x265_log(newParam, X265_LOG_DEBUG, tmp); }
+#define TOOLCMP(COND1, COND2, STR)  if (COND1 != COND2) { snprintf(tmp, sizeof(tmp), STR, COND1, COND2); x265_log(newParam, X265_LOG_DEBUG, tmp); }
     TOOLCMP(oldParam->maxNumReferences, newParam->maxNumReferences, "ref=%d to %d\n");
     TOOLCMP(oldParam->bEnableFastIntra, newParam->bEnableFastIntra, "fast-intra=%d to %d\n");
     TOOLCMP(oldParam->bEnableEarlySkip, newParam->bEnableEarlySkip, "early-skip=%d to %d\n");

--- a/source/encoder/ratecontrol.cpp
+++ b/source/encoder/ratecontrol.cpp
@@ -3245,8 +3245,8 @@ int RateControl::writeRateControlFrameStats(Frame* curFrame, RateControlEntry* r
         char bUsed[40];
         memset(deltaPOC, 0, sizeof(deltaPOC));
         memset(bUsed, 0, sizeof(bUsed));
-        sprintf(deltaPOC, "deltapoc:~");
-        sprintf(bUsed, "bused:~");
+        snprintf(deltaPOC, sizeof(deltaPOC), "deltapoc:~");
+        snprintf(bUsed, sizeof(bUsed), "bused:~");
 
         for (i = 0; i < num; i++)
         {

--- a/source/encoder/ratecontrol.cpp
+++ b/source/encoder/ratecontrol.cpp
@@ -698,7 +698,7 @@ bool RateControl::init(const SPS& sps)
                         char bUsed[40];
                         memset(deltaPOC, 0, sizeof(deltaPOC));
                         memset(bUsed, 0, sizeof(bUsed));
-                        e += sscanf(p, " in:%*d out:%*d type:%c q:%lf q-aq:%lf q-noVbv:%lf q-Rceq:%lf tex:%d mv:%d misc:%d icu:%lf pcu:%lf scu:%lf nump:%d numnegp:%d numposp:%d deltapoc:%s bused:%s",
+                        e += sscanf(p, " in:%*d out:%*d type:%c q:%lf q-aq:%lf q-noVbv:%lf q-Rceq:%lf tex:%d mv:%d misc:%d icu:%lf pcu:%lf scu:%lf nump:%d numnegp:%d numposp:%d deltapoc:%127s bused:%39s",
                             &picType, &qpRc, &qpAq, &qNoVbv, &qRceq, &rce->coeffBits,
                             &rce->mvBits, &rce->miscBits, &rce->iCuCount, &rce->pCuCount,
                             &rce->skipCuCount, &rce->rpsData.numberOfPictures, &rce->rpsData.numberOfNegativePictures, &rce->rpsData.numberOfPositivePictures, deltaPOC, bUsed);

--- a/source/encoder/ratecontrol.cpp
+++ b/source/encoder/ratecontrol.cpp
@@ -3250,8 +3250,8 @@ int RateControl::writeRateControlFrameStats(Frame* curFrame, RateControlEntry* r
 
         for (i = 0; i < num; i++)
         {
-            sprintf(deltaPOC, "%s%d~", deltaPOC, rpsWriter->deltaPOC[i]);
-            sprintf(bUsed, "%s%d~", bUsed, rpsWriter->bUsed[i]);
+            snprintf(deltaPOC, sizeof(deltaPOC), "%s%d~", deltaPOC, rpsWriter->deltaPOC[i]);
+            snprintf(bUsed, sizeof(bUsed), "%s%d~", bUsed, rpsWriter->bUsed[i]);
         }
 
         if (fprintf(m_statFileOut,

--- a/source/encoder/weightPrediction.cpp
+++ b/source/encoder/weightPrediction.cpp
@@ -516,7 +516,7 @@ void weightAnalyse(Slice& slice, Frame& frame, x265_param& param)
         int p = 0;
         bool bWeighted = false;
 
-        p = sprintf(buf, "poc: %d weights:", slice.m_poc);
+        p = snprintf(buf, sizeof(buf), "poc: %d weights:", slice.m_poc);
         int numPredDir = slice.isInterP() ? 1 : 2;
         for (int list = 0; list < numPredDir; list++)
         {
@@ -524,21 +524,21 @@ void weightAnalyse(Slice& slice, Frame& frame, x265_param& param)
             if (w[0].wtPresent || w[1].wtPresent || w[2].wtPresent)
             {
                 bWeighted = true;
-                p += sprintf(buf + p, " [L%d:R0 ", list);
+                p += snprintf(buf + p, sizeof(buf) - p, " [L%d:R0 ", list);
                 if (w[0].wtPresent)
-                    p += sprintf(buf + p, "Y{%d/%d%+d}", w[0].inputWeight, 1 << w[0].log2WeightDenom, w[0].inputOffset);
+                    p += snprintf(buf + p, sizeof(buf) - p, "Y{%d/%d%+d}", w[0].inputWeight, 1 << w[0].log2WeightDenom, w[0].inputOffset);
                 if (w[1].wtPresent)
-                    p += sprintf(buf + p, "U{%d/%d%+d}", w[1].inputWeight, 1 << w[1].log2WeightDenom, w[1].inputOffset);
+                    p += snprintf(buf + p, sizeof(buf) - p, "U{%d/%d%+d}", w[1].inputWeight, 1 << w[1].log2WeightDenom, w[1].inputOffset);
                 if (w[2].wtPresent)
-                    p += sprintf(buf + p, "V{%d/%d%+d}", w[2].inputWeight, 1 << w[2].log2WeightDenom, w[2].inputOffset);
-                p += sprintf(buf + p, "]");
+                    p += snprintf(buf + p, sizeof(buf) - p, "V{%d/%d%+d}", w[2].inputWeight, 1 << w[2].log2WeightDenom, w[2].inputOffset);
+                p += snprintf(buf + p, sizeof(buf) - p, "]");
             }
         }
 
         if (bWeighted)
         {
             if (p < 80) // pad with spaces to ensure progress line overwritten
-                sprintf(buf + p, "%*s", 80 - p, " ");
+                snprintf(buf + p, sizeof(buf) - p, "%*s", 80 - p, " ");
             x265_log(&param, X265_LOG_FULL, "%s\n", buf);
         }
     }

--- a/source/profile/vtune/vtune.cpp
+++ b/source/profile/vtune/vtune.cpp
@@ -51,7 +51,7 @@ void vtuneInit()
 void vtuneSetThreadName(const char *name, int id)
 {
     char threadname[128];
-    sprintf(threadname, "%s %d", name, id);
+    snprintf(threadname, sizeof(threadname), "%s %d", name, id);
     __itt_thread_set_name(threadname);
 }
 

--- a/source/test/pixelharness.cpp
+++ b/source/test/pixelharness.cpp
@@ -3203,7 +3203,7 @@ void PixelHarness::measurePartition(int part, const EncoderPrimitives& ref, cons
     ALIGN_VAR_16(int, cres[16]);
     pixel *fref = pbuf2 + 2 * INCR;
     char header[128];
-#define HEADER(str, ...) sprintf(header, str, __VA_ARGS__); printf("%22s", header);
+#define HEADER(str, ...) snprintf(header, sizeof(header), str, __VA_ARGS__); printf("%22s", header);
 
     if (opt.pu[part].satd)
     {
@@ -3375,7 +3375,7 @@ void PixelHarness::measureSpeed(const EncoderPrimitives& ref, const EncoderPrimi
 {
     char header[128];
 
-#define HEADER(str, ...) sprintf(header, str, __VA_ARGS__); printf("%22s", header);
+#define HEADER(str, ...) snprintf(header, sizeof(header), str, __VA_ARGS__); printf("%22s", header);
 #define HEADER0(str) printf("%22s", str);
 
     for (int size = 4; size <= 64; size *= 2)

--- a/source/x265cli.cpp
+++ b/source/x265cli.cpp
@@ -493,12 +493,12 @@ namespace X265_NS {
         if (framesToBeEncoded)
         {
             int eta = (int)(elapsed * (framesToBeEncoded - frameNum) / ((int64_t)frameNum * 1000000));
-            sprintf(buf, "x265 [%.1f%%] %d/%d frames, %.2f fps, %.2f kb/s, eta %d:%02d:%02d",
+            snprintf(buf, sizeof(buf), "x265 [%.1f%%] %d/%d frames, %.2f fps, %.2f kb/s, eta %d:%02d:%02d",
                 100. * frameNum / (param->chunkEnd ? param->chunkEnd : param->totalFrames), frameNum, (param->chunkEnd ? param->chunkEnd : param->totalFrames), fps, bitrate,
                 eta / 3600, (eta / 60) % 60, eta % 60);
         }
         else
-            sprintf(buf, "x265 %d frames: %.2f fps, %.2f kb/s", frameNum, fps, bitrate);
+            snprintf(buf, sizeof(buf), "x265 %d frames: %.2f fps, %.2f kb/s", frameNum, fps, bitrate);
 
         fprintf(stderr, "%s  \r", buf + 5);
         SetConsoleTitle(buf);
@@ -987,12 +987,12 @@ namespace X265_NS {
             int width, height;
             getParamAspectRatio(param, width, height);
             if (width && height)
-                p += sprintf(buf + p, " sar %d:%d", width, height);
+                p += snprintf(buf + p, sizeof(buf) - p, " sar %d:%d", width, height);
 
             if (framesToBeEncoded <= 0 || info[0].frameCount <= 0)
                 strcpy(buf + p, " unknown frame count");
             else
-                sprintf(buf + p, " frames %u - %d of %d", this->seek, this->seek + this->framesToBeEncoded - 1, info[0].frameCount);
+                snprintf(buf + p, sizeof(buf) - p, " frames %u - %d of %d", this->seek, this->seek + this->framesToBeEncoded - 1, info[0].frameCount);
 
             for (int view = 0; view < param->numViews - !!param->format; view++)
                 general_log(param, input[view]->getName(), X265_LOG_INFO, "%s\n", buf);

--- a/source/x265cli.cpp
+++ b/source/x265cli.cpp
@@ -981,7 +981,7 @@ namespace X265_NS {
         if (param->logLevel >= X265_LOG_INFO)
         {
             char buf[128];
-            int p = sprintf(buf, "%dx%d fps %d/%d %sp%d", param->sourceWidth, param->sourceHeight,
+            int p = snprintf(buf, sizeof(buf), "%dx%d fps %d/%d %sp%d", param->sourceWidth, param->sourceHeight,
                 param->fpsNum, param->fpsDenom, x265_source_csp_names[param->internalCsp], info[0].depth);
 
             int width, height;


### PR DESCRIPTION
**Migrated from Bitbucket PR #25**
**Author:** Vittorio Giovara
**State:** OPEN
**Created:** 2024-06-21
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/25
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/kodabb/x265:3bc90a063007%0Dcfee9638c82b?from_pullrequest_id=25&topic=true

---

* Limit buffer size operation for unsafe sprintf\(\) calls

    This function does not impose any size limitation to what it writes to, which may lead to stack buffer overflows if there is no validation on the size of the input. Use snprintf\(\) instead.


* Limit buffer size operation for unsafe sscanf\(\) calls

    This function does not impose any size limitation to what it writes to, which may lead to stack buffer overflows if there is no validation on the size of the input. Use format modifiers to read the largest possible value held by buffers instead.



‌