### PR TITLE
[BB PR #28] Fix libunwind static linking on Android toolchains

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -882,6 +882,8 @@ if(X265_LATEST_TAG)
     foreach(LIB ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES} ${PLATFORM_LIBS})
         if(IS_ABSOLUTE ${LIB} AND EXISTS ${LIB})
             list(APPEND PLIBLIST "${LIB}")
+        elseif(${LIB} MATCHES "-l:libunwind.a") # android toolchain
+            list(APPEND IMPLICITS_LIST "-lunwind")
         else()
             list(APPEND PLIBLIST "-l${LIB}")
         endif()


### PR DESCRIPTION
**Migrated from Bitbucket PR #28**
**Author:** Steve Lhomme
**State:** OPEN
**Created:** 2024-10-16
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/28
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/robux4_/x265_git:c5dd262ca6a3%0Dcfee9638c82b?from_pullrequest_id=28&topic=true

---

As well as llvm-mingw with -static-libgcc.

‌

It ends up with

> set\(CMAKE\_C\_IMPLICIT\_LINK\_LIBRARIES "atomic;m;-l:libunwind.a;dl;c;-l:libunwind.a;dl"\)

or

> set\(CMAKE\_CXX\_IMPLICIT\_LINK\_LIBRARIES "windowsapp;windowsapp;ucrt;windowsapp;ucrtapp;c\+\+;mingw32;-l:libunwind.a;moldname;mingwex;mingw32;-l:libunwind.a;moldname;mingwex"\)

‌