### PR TITLE
[BB PR #30] Fix using internal define in public header

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -32,10 +32,6 @@ option(STATIC_LINK_CRT "Statically link C and C++ runtimes for release builds" O
 mark_as_advanced(FPROFILE_USE FPROFILE_GENERATE NATIVE_BUILD)
 # X265_BUILD must be incremented each time the public API is changed
 set(X265_BUILD 215)
-configure_file("${PROJECT_SOURCE_DIR}/x265.def.in"
-               "${PROJECT_BINARY_DIR}/x265.def")
-configure_file("${PROJECT_SOURCE_DIR}/x265_config.h.in"
-               "${PROJECT_BINARY_DIR}/x265_config.h")
 
 SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" "${CMAKE_MODULE_PATH}")
 
@@ -707,6 +703,15 @@ option(ENABLE_SCC_EXT "Enable screen content coding extension in HEVC" OFF)
 if(ENABLE_SCC_EXT)
     add_definitions(-DENABLE_SCC_EXT)
 endif()
+
+set(X265_ENABLE_MULTIVIEW ${ENABLE_MULTIVIEW})
+set(X265_ENABLE_ALPHA ${ENABLE_ALPHA})
+set(X265_ENABLE_SCC_EXT ${ENABLE_SCC_EXT})
+set(X265_ENABLE_LIBVMAF ${ENABLE_LIBVMAF})
+configure_file("${PROJECT_SOURCE_DIR}/x265.def.in"
+               "${PROJECT_BINARY_DIR}/x265.def")
+configure_file("${PROJECT_SOURCE_DIR}/x265_config.h.in"
+               "${PROJECT_BINARY_DIR}/x265_config.h")
 
 add_subdirectory(encoder)
 add_subdirectory(common)

--- a/source/x265.h
+++ b/source/x265.h
@@ -640,20 +640,20 @@ typedef enum
 #define X265_MAX_GOP_LENGTH 16
 #define MAX_T_LAYERS 7
 
-#if ENABLE_MULTIVIEW
+#if X265_ENABLE_MULTIVIEW
 #define MAX_VIEWS 2
 #define MULTIVIEW_SCALABILITY_IDX         1
 #else
 #define MAX_VIEWS 1
 #endif
 
-#if ENABLE_ALPHA
+#if X265_ENABLE_ALPHA
 #define MAX_SCALABLE_LAYERS     2
 #else
 #define MAX_SCALABLE_LAYERS     1
 #endif
 
-#if ENABLE_ALPHA || ENABLE_MULTIVIEW
+#if X265_ENABLE_ALPHA || X265_ENABLE_MULTIVIEW
 #define MAX_LAYERS              2
 #define MAX_VPS_NUM_SCALABILITY_TYPES     16
 #define MAX_VPS_LAYER_ID_PLUS1            MAX_LAYERS
@@ -662,7 +662,7 @@ typedef enum
 #define MAX_LAYERS              1
 #endif
 
-#if ENABLE_SCC_EXT
+#if X265_ENABLE_SCC_EXT
 /* SCC Extension Options */
 #define SCC_EXT_IDX               3
 #define NUM_EXTENSION_FLAGS       8
@@ -2397,7 +2397,7 @@ static const char * const x265_profile_names[] = {
 
     "main444-16-intra", "main444-16-stillpicture", /* Not Supported! */
 
-#if ENABLE_SCC_EXT
+#if X265_ENABLE_SCC_EXT
     "main-scc", "main10-scc", "main444-scc", "main444-10-scc", /* Screen content coding */
 #endif
     0
@@ -2615,7 +2615,7 @@ void x265_csvlog_encode(const x265_param*, const x265_stats *, int padx, int pad
 /* In-place downshift from a bit-depth greater than 8 to a bit-depth of 8, using
  * the residual bits to dither each row. */
 void x265_dither_image(x265_picture *, int picWidth, int picHeight, int16_t *errorBuf, int bitDepth);
-#if ENABLE_LIBVMAF
+#if X265_ENABLE_LIBVMAF
 /* x265_calculate_vmafScore:
  *    returns VMAF score for the input video.
  *    This api must be called only after encoding was done. */
@@ -2687,7 +2687,7 @@ typedef struct x265_api
     void          (*csvlog_encode)(const x265_param*, const x265_stats *, int, int, int, char**);
     void          (*dither_image)(x265_picture*, int, int, int16_t*, int);
     int           (*set_analysis_data)(x265_encoder *encoder, x265_analysis_data *analysis_data, int poc, uint32_t cuBytes);
-#if ENABLE_LIBVMAF
+#if X265_ENABLE_LIBVMAF
     double        (*calculate_vmafscore)(x265_param *, x265_vmaf_data *);
     double        (*calculate_vmaf_framelevelscore)(x265_param *, x265_vmaf_framedata *);
     void          (*vmaf_encoder_log)(x265_encoder*, int, char**, x265_param *, x265_vmaf_data *);

--- a/source/x265_config.h.in
+++ b/source/x265_config.h.in
@@ -31,4 +31,9 @@
  * prevents linking against a different version of the static lib */
 #define X265_BUILD ${X265_BUILD}
 
+#cmakedefine01 X265_ENABLE_MULTIVIEW
+#cmakedefine01 X265_ENABLE_ALPHA
+#cmakedefine01 X265_ENABLE_SCC_EXT
+#cmakedefine01 X265_ENABLE_LIBVMAF
+
 #endif


### PR DESCRIPTION
**Migrated from Bitbucket PR #30**
**Author:** BtbN
**State:** OPEN
**Created:** 2024-12-08
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/30
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/BtbN/x265_git:a90ea89f9a9a%0Dcfee9638c82b?from_pullrequest_id=30&topic=true

---

Stuff like alpha layer or multilayer encoding is practically unuseable without this, unless you make assumptions and hardcode values.