### PR TITLE
[BB PR #34] feat(build): add support for CMake <3.2

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -103,8 +103,10 @@ elseif(ARM64MATCH GREATER "-1")
     # Neon I8MM is mandatory from Armv8.6.
     set(AARCH64_NEON_I8MM_FLAG "-march=armv8.2-a+dotprod+i8mm")
     set(AARCH64_SVE_FLAG "-march=armv8.2-a+dotprod+i8mm+sve")
-    # SVE2 is only available from Armv9.0, and armv9-a implies +dotprod and +sve.
-    set(AARCH64_SVE2_FLAG "-march=armv9-a+i8mm+sve2")
+    if((CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 12) OR (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 12))
+        # SVE2 is only available from Armv9.0, and armv9-a implies +dotprod and +sve.
+        set(AARCH64_SVE2_FLAG "-march=armv9-a+i8mm+sve2")
+    endif()
 else()
     message(STATUS "CMAKE_SYSTEM_PROCESSOR value `${CMAKE_SYSTEM_PROCESSOR}` is unknown")
     message(STATUS "Please add this value near ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}")

--- a/source/cmake/Version.cmake
+++ b/source/cmake/Version.cmake
@@ -126,7 +126,7 @@ elseif(GIT_ARCHETYPE)
                 #for x265 the repository changeset has to be a tag id or commit id after the tag
                 #hence mandating it's presence in version file always for valid tag distances.
                 if(DEFINED git_repositorychangeset)
-                    string(SUBSTRING "${git_repositorychangeset}" 0 9 X265_REVISION_ID)
+                    string(REGEX MATCH "^.{1,9}" X265_REVISION_ID "${git_repositorychangeset}")
                 else()
                     message(WARNING "X265 LATEST COMMIT TIP INFORMATION NOT AVAILABLE")
                 endif()


### PR DESCRIPTION
**Migrated from Bitbucket PR #34**
**Author:** Christian
**State:** OPEN
**Created:** 2025-05-11
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/34
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/various-stuff/x265_git:dddf66ff8069%0Dcfee9638c82b?from_pullrequest_id=34&topic=true

---

The build of x265 fails on distros containing CMake < 3.2 when `git_repositorychangeset` is shorter than 9 bytes. [SUBSTRING](https://cmake.org/cmake/help/latest/command/string.html#substring) tolerates this syntax in CMake 3.2 and above.

‌

See [https://github.com/tvheadend/tvheadend/pull/1797#issuecomment-2869611972](https://github.com/tvheadend/tvheadend/pull/1797#issuecomment-2869611972){: data-inline-card='' }  for reference.