### PR TITLE
[BB PR #35] RISCV64:supports RISCV compile

### DIFF
--- a/.migration-bb-pr-35.md
+++ b/.migration-bb-pr-35.md
@@ -1,0 +1,12 @@
+# Migrated from Bitbucket PR #35
+
+**Title:** RISCV64:supports RISCV compile
+**Author:** wuchangsheng
+**State:** MERGED
+**Created:** 2025-07-02
+**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/35
+**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/multicoreware/x265_git:6a7b2879187f%0D6a7b2879187f?from_pullrequest_id=35&topic=true
+
+## Description
+
+This patch is a basic enablement that supports RISC-V compile. We are working on adding vector optimizations with RISC-V RVV extensions, and will push the implementations later.


### PR DESCRIPTION
**Migrated from Bitbucket PR #35**
**Author:** wuchangsheng
**State:** MERGED
**Created:** 2025-07-02
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/35
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/multicoreware/x265_git:6a7b2879187f%0D6a7b2879187f?from_pullrequest_id=35&topic=true

> **Note:** Code already in master. Dummy commit used to preserve PR record.

---

This patch is a basic enablement that supports RISC-V compile. We are working on adding vector optimizations with RISC-V RVV extensions, and will push the implementations later.