### PR TITLE
[BB PR #36] fix(dynamicHDR10): undefined uint8_t

### DIFF
--- a/source/dynamicHDR10/json11/json11.cpp
+++ b/source/dynamicHDR10/json11/json11.cpp
@@ -22,6 +22,7 @@
 #include "json11.h"
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <cstdio>
 #include <limits>


### PR DESCRIPTION
**Migrated from Bitbucket PR #36**
**Author:** ReenigneArcher
**State:** OPEN
**Created:** 2025-07-09
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/36
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/reenignearcher/x265_git:43e696a388dd%0Dcfee9638c82b?from_pullrequest_id=36&topic=true

---

`uint8_t` is undefined when compiling with gcc15. This PR fixes the following error.  

```
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp: In function 'void json11::dump(const std::string&, std::string&)':
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:101:32: error: 'uint8_t' does not name a type
  101 |         } else if (static_cast<uint8_t>(ch) <= 0x1f) {
      |                                ^~~~~~~
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:28:1: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   27 | #include <limits>
  +++ |+#include <cstdint>
   28 | 
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:105:32: error: 'uint8_t' does not name a type
  105 |         } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
      |                                ^~~~~~~
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:105:32: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:105:68: error: 'uint8_t' does not name a type
  105 |         } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
      |                                                                    ^~~~~~~
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:105:68: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:106:35: error: 'uint8_t' does not name a type
  106 |                    && static_cast<uint8_t>(value[i+2]) == 0xa8) {
      |                                   ^~~~~~~
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:106:35: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:109:32: error: 'uint8_t' does not name a type
  109 |         } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
      |                                ^~~~~~~
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:109:32: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:109:68: error: 'uint8_t' does not name a type
  109 |         } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
      |                                                                    ^~~~~~~
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:109:68: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:110:35: error: 'uint8_t' does not name a type
  110 |                    && static_cast<uint8_t>(value[i+2]) == 0xa9) {
      |                                   ^~~~~~~
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:110:35: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp: In function 'std::string json11::esc(char)':
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:332:21: error: 'uint8_t' does not name a type
  332 |     if (static_cast<uint8_t>(c) >= 0x20 && static_cast<uint8_t>(c) <= 0x7f) {
      |                     ^~~~~~~
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:332:21: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:332:56: error: 'uint8_t' does not name a type
  332 |     if (static_cast<uint8_t>(c) >= 0x20 && static_cast<uint8_t>(c) <= 0x7f) {
      |                                                        ^~~~~~~
D:/a/build-deps/build-deps/build/generated-src/x265_git/source/dynamicHDR10/json11/json11.cpp:332:56: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
make[2]: *** [x265/dynamicHDR10/CMakeFiles/dynamicHDR10.dir/build.make:79: x265/dynamicHDR10/CMakeFiles/dynamicHDR10.dir/json11/json11.cpp.obj] Error 1
```

‌