### PR TITLE
[BB PR #44] CMake: don't force _WIN32_WINNT by default

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -769,7 +769,7 @@ if(WIN32)
     if(WINXP_SUPPORT)
         # force use of workarounds for CONDITION_VARIABLE and atomic
         # intrinsics introduced after XP
-        add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WINXP -D_WIN32_WINNT_WIN7=0x0601)
+        add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WINXP)
     else(WINXP_SUPPORT)
         # default to targeting Windows 7 for the NUMA APIs
         add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WIN7)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -768,11 +768,8 @@ if(WIN32)
     option(WINXP_SUPPORT "Make binaries compatible with Windows XP and Vista" OFF)
     if(WINXP_SUPPORT)
         # force use of workarounds for CONDITION_VARIABLE and atomic
-        # intrinsics introduced after XP
+        # intrinsics introduced after XP, otherwise using the NUMA APIs
         add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WINXP)
-    else(WINXP_SUPPORT)
-        # default to targeting Windows 7 for the NUMA APIs
-        add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WIN7)
     endif(WINXP_SUPPORT)
 endif()
 

--- a/source/common/threadpool.h
+++ b/source/common/threadpool.h
@@ -27,6 +27,10 @@
 #include "common.h"
 #include "threading.h"
 
+#ifndef _WIN32_WINNT_WIN7
+#define _WIN32_WINNT_WIN7 0x0601
+#endif
+
 namespace X265_NS {
 // x265 private namespace
 


### PR DESCRIPTION
**Migrated from Bitbucket PR #44**
**Author:** Steve Lhomme
**State:** OPEN
**Created:** 2026-01-16
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/44
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/robux4_/x265_git:8bdb069a3757%0Dcfee9638c82b?from_pullrequest_id=44&topic=true

---

* CMake: don't define \_WIN32\_WINNT\_WIN7 everywhere

    It's only needed by 2 files and can be handled in the C\+\+ code.


* CMake: don't define \_WIN32\_WINNT to Windows 7 by default

    Let the toolchain decide which OS it's targeting or using by default. All modern Windows toolchains \(MSVC, mingw-w64\) default to Windows 10.



‌