### PR TITLE
[BB PR #49] X265 pipeline

### DIFF
--- a/.migration-bb-pr-49.md
+++ b/.migration-bb-pr-49.md
@@ -1,0 +1,72 @@
+# Migrated from Bitbucket PR #49
+
+**Title:** X265 pipeline
+**Author:** Aswin
+**State:** MERGED
+**Created:** 2026-03-25
+**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/49
+**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/multicoreware/x265_git:c88725cc2825%0D8be7dbf8159d?from_pullrequest_id=49&topic=true
+
+## Description
+
+* bitbucket-pipelines.yml edited online with Bitbucket
+* Add comprehensive CI pipeline to verify full x265 functionality
+
+    Replaces placeholder pipeline with full verification suite covering 8/10/12-bit builds, multi-lib, unit tests, all presets, rate control, encoding features, analysis save/load, bitstream validation, threading, and quality metrics.
+
+
+
+    Made-with: Cursor
+
+
+* Fix pipeline YAML: remove blank lines and inline cmake commands
+
+    Bitbucket parser treats blank lines in script blocks as empty commands. Collapsed multi-line cmake flags to single lines and removed all blank lines and comments from within script blocks.
+
+
+
+    Made-with: Cursor
+
+
+* Fix TestBench path: binary is in test/ subdirectory
+
+    CMake add\_subdirectory\(test\) places TestBench under test/ in the build tree, not in the build root.
+
+
+
+    Made-with: Cursor
+
+
+* Add real-world video, 10/12-bit encoding, MCSTF/SBRC/interlace tests
+
+    New pipeline steps: - Real-world video: downloads bus\_cif and akiyo\_cif from xiph.org, encodes with multiple profiles, validates with ffprobe, uploads encoded HEVC files as artifacts for manual inspection - 10-bit and 12-bit encoding: builds high-bit-depth CLIs and runs CRF/CQP/ABR/lossless/2-pass/grain/metrics tests at 10 and 12 bit - MCSTF, SBRC, interlace: tests motion-compensated temporal filter, segment-based rate control, and TFF/BFF interlaced encoding
+
+
+
+    Also covers Y4M container input path \(previously untested\).
+
+
+
+    Made-with: Cursor
+
+
+* Add encoding summary with FPS/bitrate/QP/PSNR/SSIM to all test steps
+
+    Every test step now uses a run\_x265\(\) wrapper that captures the x265 summary line and prints a formatted summary table at the end. Added --ssim --psnr flags to real-world video, rate control, and high-bit-depth encoding steps for richer metrics.
+
+
+
+    Made-with: Cursor
+
+
+* Add combined pipeline summary report as final step
+
+    Each test step now saves its encoding summary as an artifact \(summaries/<step-name>.log\). A new final "Pipeline Summary Report" step runs after all tests complete, collecting all summaries into a single combined report with per-suite breakdowns and an overall average FPS across all encodes.
+
+
+
+    Made-with: Cursor
+
+
+
+‌


### PR DESCRIPTION
**Migrated from Bitbucket PR #49**
**Author:** Aswin
**State:** MERGED
**Created:** 2026-03-25
**Original PR:** https://bitbucket.org/multicoreware/x265_git/pull-requests/49
**Original Diff:** https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/multicoreware/x265_git:c88725cc2825%0D8be7dbf8159d?from_pullrequest_id=49&topic=true

> **Note:** Source fork inaccessible. Dummy commit used.

---

* bitbucket-pipelines.yml edited online with Bitbucket
* Add comprehensive CI pipeline to verify full x265 functionality

    Replaces placeholder pipeline with full verification suite covering 8/10/12-bit builds, multi-lib, unit tests, all presets, rate control, encoding features, analysis save/load, bitstream validation, threading, and quality metrics.



    Made-with: Cursor


* Fix pipeline YAML: remove blank lines and inline cmake commands

    Bitbucket parser treats blank lines in script blocks as empty commands. Collapsed multi-line cmake flags to single lines and removed all blank lines and comments from within script blocks.



    Made-with: Cursor


* Fix TestBench path: binary is in test/ subdirectory

    CMake add\_subdirectory\(test\) places TestBench under test/ in the build tree, not in the build root.



    Made-with: Cursor


* Add real-world video, 10/12-bit encoding, MCSTF/SBRC/interlace tests

    New pipeline steps: - Real-world video: downloads bus\_cif and akiyo\_cif from xiph.org, encodes with multiple profiles, validates with ffprobe, uploads encoded HEVC files as artifacts for manual inspection - 10-bit and 12-bit encoding: builds high-bit-depth CLIs and runs CRF/CQP/ABR/lossless/2-pass/grain/metrics tests at 10 and 12 bit - MCSTF, SBRC, interlace: tests motion-compensated temporal filter, segment-based rate control, and TFF/BFF interlaced encoding



    Also covers Y4M container input path \(previously untested\).



    Made-with: Cursor


* Add encoding summary with FPS/bitrate/QP/PSNR/SSIM to all test steps

    Every test step now uses a run\_x265\(\) wrapper that captures the x265 summary line and prints a formatted summary table at the end. Added --ssim --psnr flags to real-world video, rate control, and high-bit-depth encoding steps for richer metrics.



    Made-with: Cursor


* Add combined pipeline summary report as final step

    Each test step now saves its encoding summary as an artifact \(summaries/<step-name>.log\). A new final "Pipeline Summary Report" step runs after all tests complete, collecting all summaries into a single combined report with per-suite breakdowns and an overall average FPS across all encodes.



    Made-with: Cursor



‌