### PR TITLE
TME: early exit diamond search optimization

### DIFF
--- a/source/common/threadpool.cpp
+++ b/source/common/threadpool.cpp
@@ -371,6 +371,8 @@ static void distributeThreadsForTme(
         }
     }
     else
+#else
+    (void) bNumaSupport;
 #endif
     {
         memset(threadsPerPool, 0, sizeof(int) * (numNumaNodes + 2));

--- a/source/encoder/motion.cpp
+++ b/source/encoder/motion.cpp
@@ -642,6 +642,7 @@ int MotionEstimate::diamondSearch(ReferencePlanes* ref, const MV& mvmin, const M
 
     for (int16_t dist = 1; dist <= 4; dist <<= 1)
     {
+        const MV bmv0 = bmv;
         const int32_t top = omv.y - dist;
         const int32_t bottom = omv.y + dist;
         const int32_t left = omv.x - dist;
@@ -697,10 +698,15 @@ int MotionEstimate::diamondSearch(ReferencePlanes* ref, const MV& mvmin, const M
                 COST_MV(omv.x, bottom);
             }
         }
+
+        if (bmv == bmv0)
+            break;
     }
 
+    omv = bmv;
     for (int16_t dist = 8; dist <= 64; dist += 8)
     {
+        const MV bmv0 = bmv;
         const int32_t top = omv.y - dist;
         const int32_t bottom = omv.y + dist;
         const int32_t left = omv.x - dist;
@@ -772,6 +778,10 @@ int MotionEstimate::diamondSearch(ReferencePlanes* ref, const MV& mvmin, const M
                 }
             }
         }
+
+        if (bmv == bmv0)
+            break;
+        omv = bmv;
     }
     outMV = bmv;
     return bcost;
@@ -995,7 +1005,11 @@ int MotionEstimate::motionEstimate(ReferencePlanes *ref,
 
     pmv = pmv.roundToFPel();
     MV omv = bmv;  // current search origin or starting point
-
+    if (bcost == 0)
+    {
+        outQMv = bmv.toQPel();
+        return mvcost(bmv << 2); // return just the MV cost (no residual)
+    }
     int search = ref->isHMELowres ? (hme ? searchMethodL0 : searchMethodL1) : searchMethod;
     switch (search)
     {

--- a/source/encoder/search.cpp
+++ b/source/encoder/search.cpp
@@ -248,6 +248,7 @@ void Search::puMotionEstimation(const Slice* slice, const CUGeom& cuGeom, CUData
 
     int row = cu.m_cuAddr / m_slice->m_sps->numCuInWidth;
     int col = cu.m_cuAddr % m_slice->m_sps->numCuInWidth;
+    int slotIdx = row * m_slice->m_sps->numCuInWidth + col;
 
     int numMvc = 0;
     for (int puIdx = 0; puIdx < numPart; puIdx++)
@@ -255,7 +256,6 @@ void Search::puMotionEstimation(const Slice* slice, const CUGeom& cuGeom, CUData
         PredictionUnit pu(cu, cuGeom, puIdx);
 
         int pos = finalIdx + puIdx * puOffset;
-        int slotIdx = (col % m_slice->m_sps->numCuInWidth) * m_slice->m_sps->numCuInHeight + row;
 
         InterNeighbourMV neighbours[6];
         if(!isMVP)
@@ -2638,7 +2638,7 @@ void Search::predInterSearch(Mode& interMode, const CUGeom& cuGeom, bool bChroma
                 {
                     int row = cu.m_cuAddr / m_slice->m_sps->numCuInWidth;
                     int col = cu.m_cuAddr % m_slice->m_sps->numCuInWidth;
-                    int slotIdx = (col % m_slice->m_sps->numCuInWidth) * m_slice->m_sps->numCuInHeight + row;
+                    int slotIdx = row * m_slice->m_sps->numCuInWidth + col;
 
                     threadedMEData = slice->m_ctuMV[slotIdx * MAX_NUM_PUS_PER_CTU + index];
 


### PR DESCRIPTION
## Summary
This patch introduces early exit optimizations in the diamond search 
and motion estimation pipeline to reduce unnecessary computation in 
the TME (Threaded Motion Estimation) path.

- Reduces redundant search iterations in the motion estimation pipeline
- Improves performance for low-motion and screen-capture content
- No quality impact — early exit only triggers when search has 
  converged or a perfect match is found
