### PR TITLE
fix: scenecut not active when bframes = 0

### DIFF
--- a/source/encoder/slicetype.cpp
+++ b/source/encoder/slicetype.cpp
@@ -3175,7 +3175,7 @@ bool Lookahead::scenecut(Lowres **frames, int p0, int p1, bool bRealScenecut, in
        analysis detected scenecuts which were later nulled due to scene transitioning, in which 
        case do not return a true scenecut for this frame */
 
-    if (!frames[p1]->bScenecut)
+    if (!frames[p1]->bScenecut && m_param->bframes)
         return false;
 
     return scenecutInternal(frames, p0, p1, bRealScenecut);
@@ -3216,6 +3216,7 @@ bool Lookahead::scenecutInternal(Lowres **frames, int p0, int p1, bool bRealScen
     {
         int imb = frame->intraMbs[p1 - p0];
         int pmb = m_8x8Blocks - imb;
+        frame->bScenecut = res; // for csv log
         x265_log(m_param, X265_LOG_DEBUG, "scene cut at %d Icost:%d Pcost:%d ratio:%.4f bias:%.4f gop:%d (imb:%d pmb:%d)\n",
                  frame->frameNum, icost, pcost, 1. - (double)pcost / icost, bias, gopSize, imb, pmb);
     }


### PR DESCRIPTION
The default value of `bScenecut` is `false`.
If the bframes is 0, the flash detection is not run and this value is never changed, resulting in always-false return. CSV logging reads this value. So we change it accordingly afterwards, for consistent logging.