### PR TITLE
Adjustments to make existing CPU detection code alike. NFC

### DIFF
--- a/source/common/aarch64/cpu.h
+++ b/source/common/aarch64/cpu.h
@@ -43,9 +43,9 @@ static inline bool have_feature(const char *feature)
     return feature_present;
 }
 
-static inline int aarch64_get_cpu_flags()
+static inline uint32_t aarch64_get_cpu_flags()
 {
-    int flags = 0;
+    uint32_t flags = 0;
 
 #if HAVE_NEON
     flags |= X265_CPU_NEON;
@@ -66,9 +66,9 @@ static inline int aarch64_get_cpu_flags()
 
 #include <windows.h>
 
-static inline int aarch64_get_cpu_flags()
+static inline uint32_t aarch64_get_cpu_flags()
 {
-    int flags = 0;
+    uint32_t flags = 0;
 // IsProcessorFeaturePresent() parameter documentation:
 // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent#parameters
 #if HAVE_NEON
@@ -137,9 +137,9 @@ static inline int aarch64_get_cpu_flags()
 #define X265_AARCH64_HWCAP2_SVEBITPERM (1 << 4)
 #define X265_AARCH64_HWCAP2_I8MM (1 << 13)
 
-static inline int aarch64_get_cpu_flags()
+static inline uint32_t aarch64_get_cpu_flags()
 {
-    int flags = 0;
+    uint32_t flags = 0;
 
 #if HAVE_NEON_DOTPROD || HAVE_SVE
     unsigned long hwcap = x265_getauxval(AT_HWCAP);
@@ -177,9 +177,9 @@ static inline int aarch64_get_cpu_flags()
     "-DAARCH64_RUNTIME_CPU_DETECT=OFF."
 #endif // defined(__APPLE__)
 
-static inline int aarch64_cpu_detect()
+static inline uint32_t aarch64_cpu_detect()
 {
-    int flags = aarch64_get_cpu_flags();
+    uint32_t flags = aarch64_get_cpu_flags();
 
     // Restrict flags: FEAT_I8MM assumes that FEAT_DotProd is available.
     if (!(flags & X265_CPU_NEON_DOTPROD)) flags &= ~X265_CPU_NEON_I8MM;
@@ -199,9 +199,9 @@ static inline int aarch64_cpu_detect()
 
 #else // if AARCH64_RUNTIME_CPU_DETECT
 
-static inline int aarch64_cpu_detect()
+static inline uint32_t aarch64_cpu_detect()
 {
-    int flags = 0;
+    uint32_t flags = 0;
 
 #if HAVE_NEON
     flags |= X265_CPU_NEON;

--- a/source/common/cpu.cpp
+++ b/source/common/cpu.cpp
@@ -429,7 +429,7 @@ uint32_t cpu_detect(bool benableavx512)
 uint32_t cpu_detect(bool benableavx512)
 {
     (void)benableavx512;
-    int flags = 0;
+    uint32_t flags = 0;
 
 #ifdef ENABLE_ASSEMBLY
     flags = aarch64_cpu_detect();

--- a/source/common/riscv64/cpu.h
+++ b/source/common/riscv64/cpu.h
@@ -55,7 +55,7 @@ static int parse_proc_cpuinfo(const char *flag) {
 }
 #endif
 
-static inline uint32_t riscv64_cpu_detect()
+static inline uint32_t riscv64_get_cpu_flags()
 {
     uint32_t flags = 0;
 
@@ -79,6 +79,13 @@ static inline uint32_t riscv64_cpu_detect()
     "available for your platform. Rerun cmake configure with"          \
     "-DRISCV64_RUNTIME_CPU_DETECT=OFF."
 #endif // HAVE_GETAUXVAL || HAVE_ELF_AUX_INFO
+
+static inline uint32_t riscv64_cpu_detect()
+{
+  uint32_t flags = riscv64_get_cpu_flags();
+
+  return flags;
+}
 
 #else // if RISCV64_RUNTIME_CPU_DETECT
 


### PR DESCRIPTION
- Use uint32_t type instead of int
- Use the same naming scheme and wrapper function for OS specific
  implementations and function called from common/cpu.cpp