### PR TITLE
LoongArch64: Fix LSX and LASX checking in CMake

### DIFF
--- a/source/cmake/FindLASX.cmake
+++ b/source/cmake/FindLASX.cmake
@@ -3,11 +3,11 @@ include(FindPackageHandleStandardArgs)
 if(LOONGARCH64)
 
     set(CHECK_LASX_CODE "
-        int main(int argc, char **argv) {
-            __asm__ volatile (
-               \"xvadd.w $xr0, $xr1, $xr1\"
-            );
-           return 0; }")
+        #if defined(__loongarch_asx)
+            int main(){return 0;}
+        #else
+            #error No LASX detected!
+        #endif")
 
     check_cxx_source_compiles("${CHECK_LASX_CODE}" SUPPORTS_LASX)
 

--- a/source/cmake/FindLSX.cmake
+++ b/source/cmake/FindLSX.cmake
@@ -3,11 +3,11 @@ include(FindPackageHandleStandardArgs)
 if(LOONGARCH64)
 
     set(CHECK_LSX_CODE "
-        int main(int argc, char **argv) {
-            __asm__ volatile (
-               \"vadd.w $vr0, $vr1, $vr1\"
-            );
-            return 0; }")
+        #if defined(__loongarch_sx)
+            int main(){return 0;}
+        #else
+            #error No LSX detected!
+        #endif")
 
     check_cxx_source_compiles("${CHECK_LSX_CODE}" SUPPORTS_LSX)
 


### PR DESCRIPTION
The current source in `FindLASX.cmake` and `FindLSX.cmake` will always compile regardless of the compile option passed to CMake and GCC:

```bash
elysia@elysia-debian-3a5k:~/Projects/x265/source/build ((3f156cd09...))$ cmake -DCMAKE_CXX_FLAGS="-msimd=none" -DCMAKE_C_FLAGS="-msimd=none" ..
-- cmake version 3.31.6
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detected LOONGARCH64 target processor
-- Could NOT find Numa (missing: NUMA_ROOT_DIR NUMA_INCLUDE_DIR NUMA_LIBRARY) 
-- Looking for include file inttypes.h
-- Looking for include file inttypes.h - found
-- Performing Test SUPPORTS_LSX
-- Performing Test SUPPORTS_LSX - Success
-- Performing Test SUPPORTS_LASX
-- Performing Test SUPPORTS_LASX - Success
<Omitted>
```

This pr changes the relevent file to use internally defined marco to indentify whether LASX and LSX are enabled or not, as described in the Toolchain Conventions: <https://github.com/loongson/la-toolchain-conventions>

Below is the test output after applying the changes in this pr,

```bash
elysia@elysia-debian-3a5k:~/Projects/x265/source/build (master =)$ cmake -DCMAKE_CXX_FLAGS="-msimd=none" -DCMAKE_C_FLAGS="-msimd=none" ..
-- cmake version 3.31.6
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detected LOONGARCH64 target processor
-- Could NOT find Numa (missing: NUMA_ROOT_DIR NUMA_INCLUDE_DIR NUMA_LIBRARY) 
-- Looking for include file inttypes.h
-- Looking for include file inttypes.h - found
-- Performing Test SUPPORTS_LSX
-- Performing Test SUPPORTS_LSX - Failed
-- Performing Test SUPPORTS_LASX
-- Performing Test SUPPORTS_LASX - Failed
<Omitted>
elysia@elysia-debian-3a5k:~/Projects/x265/source/build (master =)$ rm CMakeCache.txt 
elysia@elysia-debian-3a5k:~/Projects/x265/source/build (master =)$ cmake -DCMAKE_CXX_FLAGS="-msimd=lsx" -DCMAKE_C_FLAGS="-msimd=lsx" ..
-- cmake version 3.31.6
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detected LOONGARCH64 target processor
-- Could NOT find Numa (missing: NUMA_ROOT_DIR NUMA_INCLUDE_DIR NUMA_LIBRARY) 
-- Looking for include file inttypes.h
-- Looking for include file inttypes.h - found
-- Performing Test SUPPORTS_LSX
-- Performing Test SUPPORTS_LSX - Success
-- Performing Test SUPPORTS_LASX
-- Performing Test SUPPORTS_LASX - Failed
<Omitted>
elysia@elysia-debian-3a5k:~/Projects/x265/source/build (master =)$ rm CMakeCache.txt 
elysia@elysia-debian-3a5k:~/Projects/x265/source/build (master =)$ cmake -DCMAKE_CXX_FLAGS="-msimd=lasx" -DCMAKE_C_FLAGS="-msimd=lasx" ..
-- cmake version 3.31.6
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detected LOONGARCH64 target processor
-- Could NOT find Numa (missing: NUMA_ROOT_DIR NUMA_INCLUDE_DIR NUMA_LIBRARY) 
-- Looking for include file inttypes.h
-- Looking for include file inttypes.h - found
-- Performing Test SUPPORTS_LSX
-- Performing Test SUPPORTS_LSX - Success
-- Performing Test SUPPORTS_LASX
-- Performing Test SUPPORTS_LASX - Success
<Omitted>
```bash