### PR TITLE
LoongArch64: Some further cleaning and tweaking of the run-time support

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -138,7 +138,7 @@ elseif(LOONGARCH64MATCH GREATER "-1")
     message(STATUS "Detected LOONGARCH64 target processor")
 
     option(LOONGARCH64_RUNTIME_CPU_DETECT "Enable LOONGARCH64 run-time CPU feature detection" ON)
-    if(NOT CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD|OpenBSD")
+    if(NOT CMAKE_SYSTEM_NAME MATCHES "Linux")
         set(LOONGARCH64_RUNTIME_CPU_DETECT OFF CACHE BOOL "" FORCE)
         message(STATUS "Run-time CPU feature detection unsupported on this platform")
     endif()

--- a/source/common/cpu.cpp
+++ b/source/common/cpu.cpp
@@ -461,6 +461,7 @@ uint32_t cpu_detect(bool benableavx512)
 
 uint32_t cpu_detect( bool benableavx512 )
 {
+    (void)benableavx512;
     uint32_t flags = 0;
 
 #ifdef ENABLE_ASSEMBLY

--- a/source/common/loongarch64/cpu.h
+++ b/source/common/loongarch64/cpu.h
@@ -28,12 +28,14 @@
 
 #if LOONGARCH64_RUNTIME_CPU_DETECT
 
+#if HAVE_GETAUXVAL
+
 #include <sys/auxv.h>
 
 #define LA_HWCAP_LSX    ( 1U << 4 )
 #define LA_HWCAP_LASX   ( 1U << 5 )
 
-static inline uint32_t loongarch64_cpu_detect()
+static inline uint32_t loongarch64_get_cpu_flags()
 {
     uint32_t flags = 0;
 #if HAVE_LSX || HAVE_LSX
@@ -48,6 +50,20 @@ static inline uint32_t loongarch64_cpu_detect()
     if( hwcap & LA_HWCAP_LASX )
         flags |= X265_CPU_LASX;
 #endif
+
+    return flags;
+}
+
+#else // HAVE_GETAUXVAL
+#error                                                                 \
+    "Run-time CPU feature detection selected, but no detection method" \
+    "available for your platform. Rerun cmake configure with"          \
+    "-DLOONGARCH64_RUNTIME_CPU_DETECT=OFF."
+#endif // HAVE_GETAUXVAL
+
+static inline uint32_t loongarch64_cpu_detect()
+{
+    uint32_t flags = loongarch64_get_cpu_flags();
 
     return flags;
 }


### PR DESCRIPTION
- Wrap the CPU detection code with HAVE_GETAUXVAL
- Have run-time support only enabled on Linux so far
- Quiet warning about benableavx512