### PR TITLE
x265.h: Avoid -Wundef warnings for undefined preprocessor macros

### DIFF
--- a/source/x265.h
+++ b/source/x265.h
@@ -32,7 +32,7 @@
 extern "C" {
 #endif
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #pragma warning(disable: 4201) // non-standard extension used (nameless struct/union)
 #endif
 
@@ -183,7 +183,7 @@ typedef struct x265_weight_param
     int      wtPresent;
 }x265_weight_param;
 
-#if X265_DEPTH < 10
+#if defined(X265_DEPTH) && X265_DEPTH < 10
 typedef uint32_t sse_t;
 #else
 typedef uint64_t sse_t;
@@ -2645,7 +2645,7 @@ void x265_csvlog_encode(const x265_param*, const x265_stats *, int padx, int pad
 /* In-place downshift from a bit-depth greater than 8 to a bit-depth of 8, using
  * the residual bits to dither each row. */
 void x265_dither_image(x265_picture *, int picWidth, int picHeight, int16_t *errorBuf, int bitDepth);
-#if ENABLE_LIBVMAF
+#if defined(ENABLE_LIBVMAF) && ENABLE_LIBVMAF
 /* x265_calculate_vmafScore:
  *    returns VMAF score for the input video.
  *    This api must be called only after encoding was done. */
@@ -2717,7 +2717,7 @@ typedef struct x265_api
     void          (*csvlog_encode)(const x265_param*, const x265_stats *, int, int, int, char**);
     void          (*dither_image)(x265_picture*, int, int, int16_t*, int);
     int           (*set_analysis_data)(x265_encoder *encoder, x265_analysis_data *analysis_data, int poc, uint32_t cuBytes);
-#if ENABLE_LIBVMAF
+#if defined(ENABLE_LIBVMAF) && ENABLE_LIBVMAF
     double        (*calculate_vmafscore)(x265_param *, x265_vmaf_data *);
     double        (*calculate_vmaf_framelevelscore)(x265_param *, x265_vmaf_framedata *);
     void          (*vmaf_encoder_log)(x265_encoder*, int, char**, x265_param *, x265_vmaf_data *);


### PR DESCRIPTION
## Summary

Fix `-Wundef` warnings emitted by the public `x265.h` header when included by external projects compiled with `-Wundef`.

The header currently uses `#if` directives with macros that may not be defined, resulting in warnings such as:

```
warning: "_MSC_VER" is not defined, evaluates to 0 [-Wundef]
warning: "X265_DEPTH" is not defined, evaluates to 0 [-Wundef]
warning: "ENABLE_LIBVMAF" is not defined, evaluates to 0 [-Wundef]
```

This patch updates the preprocessor checks to use `#ifdef` or `defined(...)` where appropriate, avoiding evaluation of undefined macros while preserving existing behavior when the macros are defined.

## Changes

* Replace `#if _MSC_VER` with `#ifdef _MSC_VER`.
* Replace `#if X265_DEPTH < 10` with `#if defined(X265_DEPTH) && X265_DEPTH < 10`.
* Replace both occurrences of `#if ENABLE_LIBVMAF` with `#if defined(ENABLE_LIBVMAF) && ENABLE_LIBVMAF`.

## Validation

Reproduced the issue on Ubuntu using GCC by compiling a simple program that includes `x265.h` with `-Wundef` enabled:

```bash
gcc -Wundef -Wall -Wextra -Isource -c source/test.c
```

Before the change, the compiler reported `-Wundef` warnings for `_MSC_VER`, `X265_DEPTH`, and `ENABLE_LIBVMAF`.

After applying the patch, the warnings are no longer emitted.

## Impact

This change does not alter runtime behavior or API functionality. It only improves compatibility for downstream projects that include the installed `x265.h` header and build with strict compiler warning flags such as `-Wundef`.
