### PR TITLE
Fix i686 build failure caused by non-PC-relative PLT references

### DIFF
--- a/source/common/x86/cpu-a.asm
+++ b/source/common/x86/cpu-a.asm
@@ -177,7 +177,7 @@ cglobal safe_intel_cpu_indicator_init
 %if WIN64
     lea rax, [intel_cpu_indicator_init]
     call rax
-%elif FORMAT_ELF
+%elif UNIX64 && FORMAT_ELF
     call [rel intel_cpu_indicator_init wrt ..plt]
 %else
     call intel_cpu_indicator_init


### PR DESCRIPTION
**Original patch suggested by Zeckma Tech (Bitbucket username : Zeckma Tech)**

**Summary**

Fixes the i686 build failure caused by non-PC-relative PLT references when building x265 4.2.

**Changes**

- Update the affected code to avoid generating non-PC-relative PLT references on i686.
- Preserve existing behavior on other architectures.
- No functional changes to encoding behavior; this change only affects build compatibility.