### PR TITLE
Fix TSAN warnings

### DIFF
--- a/source/abrEncApp.cpp
+++ b/source/abrEncApp.cpp
@@ -35,10 +35,10 @@
 using namespace X265_NS;
 
 /* Ctrl-C handler */
-static volatile sig_atomic_t b_ctrl_c /* = 0 */;
+static AtomicBool b_ctrl_c /* = 0 */;
 static void sigint_handler(int)
 {
-    b_ctrl_c = 1;
+    b_ctrl_c = true;
 }
 
 namespace X265_NS {
@@ -815,7 +815,7 @@ ret:
 
                     if (numEncoded < 0)
                     {
-                        b_ctrl_c = 1;
+                        b_ctrl_c = true;
                         m_ret = 4;
                         break;
                     }

--- a/source/common/cudata.h
+++ b/source/common/cudata.h
@@ -27,6 +27,7 @@
 #include "common.h"
 #include "slice.h"
 #include "mv.h"
+#include "threading.h"
 
 #define NUM_TU_DEPTH 21
 
@@ -173,7 +174,7 @@ const uint32_t partAddrTable[8][4] =
 class CUData
 {
 public:
-
+    mutable Lock m_accessLock;
     cubcast_t s_partSet[NUM_FULL_DEPTH]; // pointer to broadcast set functions per absolute depth
     uint32_t  s_numPartInCUSize;
 
@@ -271,7 +272,11 @@ public:
     void     clearCbf()                            { m_partSet(m_cbf[0], 0); if (m_chromaFormat != X265_CSP_I400) { m_partSet(m_cbf[1], 0); m_partSet(m_cbf[2], 0);} }
 
     /* these functions all take depth as an absolute depth from CTU, it is used to calculate the number of parts to copy */
-    void     setQPSubParts(int8_t qp, uint32_t absPartIdx, uint32_t depth)                    { s_partSet[depth]((uint8_t*)m_qp + absPartIdx, (uint8_t)qp); }
+    void     setQPSubParts(int8_t qp, uint32_t absPartIdx, uint32_t depth)
+    {
+        ScopedLock lock(m_accessLock);
+        s_partSet[depth]((uint8_t*)m_qp + absPartIdx, (uint8_t)qp);
+    }
     void     setTUDepthSubParts(uint8_t tuDepth, uint32_t absPartIdx, uint32_t depth)         { s_partSet[depth](m_tuDepth + absPartIdx, tuDepth); }
     void     setLumaIntraDirSubParts(uint8_t dir, uint32_t absPartIdx, uint32_t depth)        { s_partSet[depth](m_lumaIntraDir + absPartIdx, dir); }
     void     setChromIntraDirSubParts(uint8_t dir, uint32_t absPartIdx, uint32_t depth)       { s_partSet[depth](m_chromaIntraDir + absPartIdx, dir); }

--- a/source/common/cudata.h
+++ b/source/common/cudata.h
@@ -275,7 +275,7 @@ public:
     void     setQPSubParts(int8_t qp, uint32_t absPartIdx, uint32_t depth)
     {
         ScopedSpinLock lock(m_accessLock);
-        s_partSet[depth]((uint8_t*)m_qp + absPartIdx, (uint8_t)qp);
+        s_partSet[depth](reinterpret_cast<uint8_t*>(m_qp) + absPartIdx, (uint8_t)qp);
     }
     void     setTUDepthSubParts(uint8_t tuDepth, uint32_t absPartIdx, uint32_t depth)         { s_partSet[depth](m_tuDepth + absPartIdx, tuDepth); }
     void     setLumaIntraDirSubParts(uint8_t dir, uint32_t absPartIdx, uint32_t depth)        { s_partSet[depth](m_lumaIntraDir + absPartIdx, dir); }

--- a/source/common/cudata.h
+++ b/source/common/cudata.h
@@ -174,7 +174,7 @@ const uint32_t partAddrTable[8][4] =
 class CUData
 {
 public:
-    mutable Lock m_accessLock;
+    mutable SpinLock m_accessLock;
     cubcast_t s_partSet[NUM_FULL_DEPTH]; // pointer to broadcast set functions per absolute depth
     uint32_t  s_numPartInCUSize;
 
@@ -274,7 +274,7 @@ public:
     /* these functions all take depth as an absolute depth from CTU, it is used to calculate the number of parts to copy */
     void     setQPSubParts(int8_t qp, uint32_t absPartIdx, uint32_t depth)
     {
-        ScopedLock lock(m_accessLock);
+        ScopedSpinLock lock(m_accessLock);
         s_partSet[depth]((uint8_t*)m_qp + absPartIdx, (uint8_t)qp);
     }
     void     setTUDepthSubParts(uint8_t tuDepth, uint32_t absPartIdx, uint32_t depth)         { s_partSet[depth](m_tuDepth + absPartIdx, tuDepth); }

--- a/source/common/frame.cpp
+++ b/source/common/frame.cpp
@@ -31,7 +31,6 @@ using namespace X265_NS;
 
 Frame::Frame()
 {
-    m_bChromaExtended = false;
     m_lowresInit = false;
     m_reconRowFlag = NULL;
     m_reconColCount = NULL;
@@ -253,7 +252,6 @@ bool Frame::allocEncodeData(x265_param *param, const SPS& sps)
 /* prepare to re-use a FrameData instance to encode a new picture */
 void Frame::reinit(const SPS& sps)
 {
-    m_bChromaExtended = false;
     for (int i = 0; i < !!m_param->bEnableSCC + 1; i++)
         m_reconPic[i] = m_encData->m_reconPic[i];
     m_encData->reinit(sps);

--- a/source/common/frame.h
+++ b/source/common/frame.h
@@ -102,7 +102,7 @@ public:
 
     Lowres                 m_lowres;
     bool                   m_lowresInit;         // lowres init complete (pre-analysis)
-    bool                   m_bChromaExtended;    // orig chroma planes motion extended for weight analysis
+    AtomicBool             m_bChromaExtended;    // orig chroma planes motion extended for weight analysis
     bool                   m_reconfigureRc;
 
     float*                 m_quantOffsets;       // points to quantOffsets in x265_picture
@@ -115,7 +115,7 @@ public:
     ThreadSafeInteger*     m_reconColCount;      // count of CTU cols completely reconstructed and extended for motion reference
     ThreadSafeInteger*     m_ctuMEFlags;         // Flag to indicate if threaded me has completed processsing for CTUs
     int32_t                m_numRows;
-    volatile uint32_t      m_countRefEncoders;   // count of FrameEncoder threads monitoring m_reconRowCount
+    AtomicInt32            m_countRefEncoders;   // count of FrameEncoder threads monitoring m_reconRowCount
 
     Frame*                 m_next;               // PicList doubly linked list pointers
     Frame*                 m_prev;

--- a/source/common/frame.h
+++ b/source/common/frame.h
@@ -102,7 +102,6 @@ public:
 
     Lowres                 m_lowres;
     bool                   m_lowresInit;         // lowres init complete (pre-analysis)
-    AtomicBool             m_bChromaExtended;    // orig chroma planes motion extended for weight analysis
     bool                   m_reconfigureRc;
 
     float*                 m_quantOffsets;       // points to quantOffsets in x265_picture

--- a/source/common/framedata.h
+++ b/source/common/framedata.h
@@ -126,8 +126,6 @@ public:
     RPS*           m_spsrps;
     int            m_spsrpsIdx;
 
-    Lock m_rowStatLock;
-
     /* Rate control data used during encode and by references */
     struct RCStatCU
     {
@@ -147,8 +145,8 @@ public:
         uint32_t intraSatdForVbv; /* sum of lowres (estimated) intra costs for entire row */
         AtomicUInt32 rowSatd;
         AtomicUInt32 rowIntraSatd;
-        double   rowQp;
-        double   rowQpScale;
+        AtomicDouble rowQp;
+        AtomicDouble rowQpScale;
         double   sumQpRc;
         double   sumQpAq;
     };

--- a/source/common/framedata.h
+++ b/source/common/framedata.h
@@ -126,6 +126,8 @@ public:
     RPS*           m_spsrps;
     int            m_spsrpsIdx;
 
+    Lock m_rowStatLock;
+
     /* Rate control data used during encode and by references */
     struct RCStatCU
     {
@@ -139,12 +141,12 @@ public:
 
     struct RCStatRow
     {
-        uint32_t numEncodedCUs; /* ctuAddr of last encoded CTU in row */
-        uint32_t encodedBits;   /* sum of 'totalBits' of encoded CTUs */
+        AtomicUInt32 numEncodedCUs; /* ctuAddr of last encoded CTU in row */
+        AtomicUInt32 encodedBits;   /* sum of 'totalBits' of encoded CTUs */
         uint32_t satdForVbv;    /* sum of lowres (estimated) costs for entire row */
         uint32_t intraSatdForVbv; /* sum of lowres (estimated) intra costs for entire row */
-        uint32_t rowSatd;
-        uint32_t rowIntraSatd;
+        AtomicUInt32 rowSatd;
+        AtomicUInt32 rowIntraSatd;
         double   rowQp;
         double   rowQpScale;
         double   sumQpRc;

--- a/source/common/lowres.h
+++ b/source/common/lowres.h
@@ -28,6 +28,7 @@
 #include "common.h"
 #include "picyuv.h"
 #include "mv.h"
+#include "threading.h"
 
 namespace X265_NS {
 // private namespace
@@ -48,7 +49,7 @@ struct ReferencePlanes
     pixel*   fpelLowerResPlane[3];
     pixel*   lowerResPlane[4];
 
-    bool     isWeighted;
+    AtomicBool     isWeighted;
     bool     isLowres;
     bool     isHMELowres;
 

--- a/source/common/threading.h
+++ b/source/common/threading.h
@@ -70,6 +70,10 @@ int64_t no_atomic_add64(int64_t* ptr, int64_t val);
 #define ATOMIC_ADD(ptr, val)  (sizeof(*(ptr)) == 8 ? \
                                no_atomic_add64((int64_t*)ptr, (int64_t)(val)) : \
                                no_atomic_add((int*)ptr, (int)(val)))
+#define ATOMIC_STORE(ptr, val)    (*(ptr) = (int)(val))
+#define ATOMIC64_LOAD(ptr)        (*(ptr))
+#define ATOMIC64_STORE(ptr, val)  (*(ptr) = (val))
+#define ATOMIC64_ADD(ptr, val)    (*(ptr) += (val))
 #define GIVE_UP_TIME()        usleep(0)
 
 #elif __GNUC__               /* GCCs builtin atomics */
@@ -86,6 +90,10 @@ int64_t no_atomic_add64(int64_t* ptr, int64_t val);
 #define ATOMIC_INC(ptr)       __sync_add_and_fetch((volatile int32_t*)ptr, 1)
 #define ATOMIC_DEC(ptr)       __sync_add_and_fetch((volatile int32_t*)ptr, -1)
 #define ATOMIC_ADD(ptr, val)  __sync_fetch_and_add((volatile __typeof__(*(ptr))*)ptr, (__typeof__(*(ptr) + 0))(val))
+#define ATOMIC_STORE(ptr, val)    __sync_lock_test_and_set((volatile int32_t*)ptr, (int32_t)(val))
+#define ATOMIC64_LOAD(ptr)        __sync_fetch_and_add((volatile int64_t*)ptr, 0)
+#define ATOMIC64_STORE(ptr, val)  __sync_lock_test_and_set((volatile int64_t*)ptr, val)
+#define ATOMIC64_ADD(ptr, val)    __sync_fetch_and_add((volatile int64_t*)ptr, val)
 #define GIVE_UP_TIME()        usleep(0)
 
 #elif defined(_MSC_VER)       /* Windows atomic intrinsics */
@@ -103,6 +111,10 @@ int64_t no_atomic_add64(int64_t* ptr, int64_t val);
                                InterlockedExchangeAdd((volatile LONG*)ptr, (LONG)(val)))
 #define ATOMIC_OR(ptr, mask)  _InterlockedOr((volatile LONG*)ptr, (LONG)mask)
 #define ATOMIC_AND(ptr, mask) _InterlockedAnd((volatile LONG*)ptr, (LONG)mask)
+#define ATOMIC_STORE(ptr, val)    InterlockedExchange((volatile LONG*)ptr, (LONG)(val))
+#define ATOMIC64_LOAD(ptr)        InterlockedAdd64((volatile LONG64*)ptr, 0)
+#define ATOMIC64_STORE(ptr, val)  InterlockedExchange64((volatile LONG64*)ptr, val)
+#define ATOMIC64_ADD(ptr, val)    InterlockedAdd64((volatile LONG64*)ptr, val)
 #define GIVE_UP_TIME()        Sleep(0)
 
 #endif // ifdef __GNUC__
@@ -452,8 +464,9 @@ public:
         pthread_mutex_lock(&m_mutex);
         if (m_val == prev)
             pthread_cond_wait(&m_cond, &m_mutex);
+        int ret = m_val;
         pthread_mutex_unlock(&m_mutex);
-        return m_val;
+        return ret;
     }
 
     int get()
@@ -827,6 +840,144 @@ protected:
 
     // do not allow assignments
     ScopedElapsedTime &operator =(const ScopedElapsedTime &);
+};
+
+/* Atomic wrapper classes for C++98 compatible thread-safe access.
+ * These replace raw ATOMIC_* macro calls at every site with a type
+ * that enforces atomic access automatically through operator overloads.
+ * Declaring a variable as AtomicBool/AtomicInt32/AtomicInt64 makes it
+ * impossible to access it non-atomically by accident. */
+
+class AtomicBool
+{
+public:
+    AtomicBool() : m_val(0) {}
+    AtomicBool(bool v) : m_val(v ? 1 : 0) {}
+
+    operator bool() const
+    {
+        return (int32_t)ATOMIC_OR(&m_val, 0) != 0;
+    }
+
+    AtomicBool& operator=(bool v)
+    {
+        ATOMIC_STORE(&m_val, v ? 1 : 0);
+        return *this;
+    }
+
+private:
+    AtomicBool(const AtomicBool&);
+    AtomicBool& operator=(const AtomicBool&);
+    mutable volatile int32_t m_val;
+};
+
+class AtomicInt32
+{
+public:
+    AtomicInt32() : m_val(0) {}
+    AtomicInt32(int32_t v) : m_val(v) {}
+
+    operator int32_t() const
+    {
+        return (int32_t)ATOMIC_OR(&m_val, 0);
+    }
+
+    AtomicInt32& operator=(int32_t v)
+    {
+        ATOMIC_STORE(&m_val, v);
+        return *this;
+    }
+
+    int32_t operator++()
+    {
+        return (int32_t)ATOMIC_INC(&m_val);
+    }
+
+    int32_t operator--()
+    {
+        return (int32_t)ATOMIC_DEC(&m_val);
+    }
+
+    int32_t fetchAdd(int32_t v)
+    {
+        return (int32_t)ATOMIC_ADD(&m_val, v);
+    }
+
+    int32_t fetchOr(int32_t mask)
+    {
+        return (int32_t)ATOMIC_OR(&m_val, mask);
+    }
+
+    int32_t fetchAnd(int32_t mask)
+    {
+        return (int32_t)ATOMIC_AND(&m_val, mask);
+    }
+
+private:
+    AtomicInt32(const AtomicInt32&);
+    AtomicInt32& operator=(const AtomicInt32&);
+    mutable volatile int32_t m_val;
+};
+
+class AtomicInt64
+{
+public:
+    AtomicInt64() : m_val(0) {}
+    AtomicInt64(int64_t v) : m_val(v) {}
+
+    operator int64_t() const
+    {
+        return (int64_t)ATOMIC64_LOAD(&m_val);
+    }
+
+    AtomicInt64& operator=(int64_t v)
+    {
+        ATOMIC64_STORE(&m_val, v);
+        return *this;
+    }
+
+    void add(int64_t v)
+    {
+        ATOMIC64_ADD(&m_val, v);
+    }
+
+private:
+    AtomicInt64(const AtomicInt64&);
+    AtomicInt64& operator=(const AtomicInt64&);
+    mutable volatile int64_t m_val;
+};
+
+class AtomicUInt32
+{
+public:
+    AtomicUInt32() : m_val(0) {}
+    AtomicUInt32(uint32_t v) : m_val(v) {}
+
+    operator uint32_t() const
+    {
+        return (uint32_t)ATOMIC_OR(&m_val, 0);
+    }
+
+    AtomicUInt32& operator=(uint32_t v)
+    {
+        ATOMIC_STORE(&m_val, (int32_t)v);
+        return *this;
+    }
+
+    uint32_t operator++()
+    {
+        return (uint32_t)ATOMIC_INC(&m_val);
+    }
+
+    uint32_t fetchAdd(uint32_t v)
+    {
+        return (uint32_t)ATOMIC_ADD(&m_val, (int32_t)v);
+    }
+
+private:
+    AtomicUInt32(const AtomicUInt32&);
+    AtomicUInt32& operator=(const AtomicUInt32&);
+    mutable volatile int32_t m_val;
 };
 
 //< Simplistic portable thread class.  Shutdown signalling left to derived class

--- a/source/common/threading.h
+++ b/source/common/threading.h
@@ -825,6 +825,44 @@ protected:
     Lock &inst;
 };
 
+/* Lock-free spin lock using platform atomic ops (no CRITICAL_SECTION on Windows).
+ * TSan-friendly because acquire/release use the same ATOMIC_OR/ATOMIC_STORE
+ * intrinsics that TSan understands as synchronization points. */
+class SpinLock
+{
+public:
+    SpinLock() : m_val(0) {}
+    /* Copy-construct as a fresh unlocked instance — the lock state itself
+     * must never be copied (same semantics as std::mutex). */
+    SpinLock(const SpinLock&) : m_val(0) {}
+    SpinLock& operator=(const SpinLock&) { return *this; }
+
+    void acquire()
+    {
+        while (ATOMIC_OR(&m_val, 1) & 1)
+            GIVE_UP_TIME();
+    }
+
+    void release()
+    {
+        ATOMIC_STORE(&m_val, 0);
+    }
+
+private:
+    mutable volatile int32_t m_val;
+};
+
+class ScopedSpinLock
+{
+public:
+    ScopedSpinLock(SpinLock& instance) : inst(instance) { inst.acquire(); }
+    ~ScopedSpinLock() { inst.release(); }
+
+protected:
+    ScopedSpinLock& operator=(const ScopedSpinLock&);
+    SpinLock& inst;
+};
+
 // Utility class which adds elapsed time of the scope of the object into the
 // accumulator provided to the constructor
 struct ScopedElapsedTime
@@ -887,6 +925,7 @@ public:
     Atomic& operator=(T v)      { Ops::store(&m_val, (Storage)v); return *this; }
 
     T operator++()              { return (T)Ops::inc(&m_val); }
+    T operator++(int)           { return fetchAdd((T)1); }
     T operator--()              { return (T)Ops::dec(&m_val); }
     T fetchAdd(T v)             { return (T)Ops::add(&m_val, (Storage)v); }
     T fetchOr(T mask)           { return (T)Ops::fetchOr(&m_val, (Storage)mask); }
@@ -902,6 +941,40 @@ private:
 typedef Atomic<int32_t>  AtomicInt32;
 typedef Atomic<uint32_t> AtomicUInt32;
 typedef Atomic<int64_t>  AtomicInt64;
+
+/* Lock-free atomic double using int64_t storage with memcpy bit-casting.
+ * Needed because Atomic<T> casts through Storage (int64_t), which truncates
+ * floating-point values. This uses the same ATOMIC64_LOAD/STORE macros and
+ * works across all three platform backends (no-atomics, GCC, MSVC). */
+class AtomicDouble
+{
+public:
+    AtomicDouble() : m_val(0) {}
+    AtomicDouble(double v) { store(v); }
+
+    double load() const
+    {
+        int64_t bits = ATOMIC64_LOAD(&m_val);
+        double result;
+        memcpy(&result, &bits, sizeof(double));
+        return result;
+    }
+
+    void store(double v)
+    {
+        int64_t bits;
+        memcpy(&bits, &v, sizeof(double));
+        ATOMIC64_STORE(&m_val, bits);
+    }
+
+    operator double() const        { return load(); }
+    AtomicDouble& operator=(double v) { store(v); return *this; }
+
+private:
+    AtomicDouble(const AtomicDouble&);
+    AtomicDouble& operator=(const AtomicDouble&);
+    mutable volatile int64_t m_val;
+};
 
 /* Exclusive wrapper rather than an Atomic<bool> (as sizeof(bool) is not 4). */
 class AtomicBool

--- a/source/common/threading.h
+++ b/source/common/threading.h
@@ -848,6 +848,62 @@ protected:
  * Declaring a variable as AtomicBool/AtomicInt32/AtomicInt64 makes it
  * impossible to access it non-atomically by accident. */
 
+/* Generic abstraction for atomic operations on integers of various sizes (4 vs 8 bytes). */
+template<int N> struct AtomicOps;
+
+template<> struct AtomicOps<4>
+{
+    typedef int32_t Storage;
+    static int32_t load(volatile Storage* p)              { return (int32_t)ATOMIC_OR(p, 0); }
+    static void    store(volatile Storage* p, int32_t v)  { ATOMIC_STORE(p, v); }
+    static int32_t inc(volatile Storage* p)               { return (int32_t)ATOMIC_INC(p); }
+    static int32_t dec(volatile Storage* p)               { return (int32_t)ATOMIC_DEC(p); }
+    static int32_t add(volatile Storage* p, int32_t v)    { return (int32_t)ATOMIC_ADD(p, v); }
+    static int32_t fetchOr(volatile Storage* p, int32_t m){ return (int32_t)ATOMIC_OR(p, m); }
+    static int32_t fetchAnd(volatile Storage* p, int32_t m){ return (int32_t)ATOMIC_AND(p, m); }
+};
+
+template<> struct AtomicOps<8>
+{
+    typedef int64_t Storage;
+    static int64_t load(volatile Storage* p)              { return (int64_t)ATOMIC64_LOAD(p); }
+    static void    store(volatile Storage* p, int64_t v)  { ATOMIC64_STORE(p, v); }
+    static int64_t add(volatile Storage* p, int64_t v)    { return (int64_t)ATOMIC64_ADD(p, v); }
+};
+
+/* Generic atomic integer */
+template<typename T>
+class Atomic
+{
+    typedef AtomicOps<sizeof(T)> Ops;
+    typedef typename Ops::Storage Storage;
+
+public:
+    Atomic() : m_val(0) {}
+    Atomic(T v) : m_val((Storage)v) {}
+
+    operator T() const          { return (T)Ops::load(&m_val); }
+
+    Atomic& operator=(T v)      { Ops::store(&m_val, (Storage)v); return *this; }
+
+    T operator++()              { return (T)Ops::inc(&m_val); }
+    T operator--()              { return (T)Ops::dec(&m_val); }
+    T fetchAdd(T v)             { return (T)Ops::add(&m_val, (Storage)v); }
+    T fetchOr(T mask)           { return (T)Ops::fetchOr(&m_val, (Storage)mask); }
+    T fetchAnd(T mask)          { return (T)Ops::fetchAnd(&m_val, (Storage)mask); }
+    void add(T v)               { Ops::add(&m_val, (Storage)v); }
+
+private:
+    Atomic(const Atomic&);
+    Atomic& operator=(const Atomic&);
+    mutable volatile Storage m_val;
+};
+
+typedef Atomic<int32_t>  AtomicInt32;
+typedef Atomic<uint32_t> AtomicUInt32;
+typedef Atomic<int64_t>  AtomicInt64;
+
+/* Exclusive wrapper rather than an Atomic<bool> (as sizeof(bool) is not 4). */
 class AtomicBool
 {
 public:
@@ -868,115 +924,6 @@ public:
 private:
     AtomicBool(const AtomicBool&);
     AtomicBool& operator=(const AtomicBool&);
-    mutable volatile int32_t m_val;
-};
-
-class AtomicInt32
-{
-public:
-    AtomicInt32() : m_val(0) {}
-    AtomicInt32(int32_t v) : m_val(v) {}
-
-    operator int32_t() const
-    {
-        return (int32_t)ATOMIC_OR(&m_val, 0);
-    }
-
-    AtomicInt32& operator=(int32_t v)
-    {
-        ATOMIC_STORE(&m_val, v);
-        return *this;
-    }
-
-    int32_t operator++()
-    {
-        return (int32_t)ATOMIC_INC(&m_val);
-    }
-
-    int32_t operator--()
-    {
-        return (int32_t)ATOMIC_DEC(&m_val);
-    }
-
-    int32_t fetchAdd(int32_t v)
-    {
-        return (int32_t)ATOMIC_ADD(&m_val, v);
-    }
-
-    int32_t fetchOr(int32_t mask)
-    {
-        return (int32_t)ATOMIC_OR(&m_val, mask);
-    }
-
-    int32_t fetchAnd(int32_t mask)
-    {
-        return (int32_t)ATOMIC_AND(&m_val, mask);
-    }
-
-private:
-    AtomicInt32(const AtomicInt32&);
-    AtomicInt32& operator=(const AtomicInt32&);
-    mutable volatile int32_t m_val;
-};
-
-class AtomicInt64
-{
-public:
-    AtomicInt64() : m_val(0) {}
-    AtomicInt64(int64_t v) : m_val(v) {}
-
-    operator int64_t() const
-    {
-        return (int64_t)ATOMIC64_LOAD(&m_val);
-    }
-
-    AtomicInt64& operator=(int64_t v)
-    {
-        ATOMIC64_STORE(&m_val, v);
-        return *this;
-    }
-
-    void add(int64_t v)
-    {
-        ATOMIC64_ADD(&m_val, v);
-    }
-
-private:
-    AtomicInt64(const AtomicInt64&);
-    AtomicInt64& operator=(const AtomicInt64&);
-    mutable volatile int64_t m_val;
-};
-
-class AtomicUInt32
-{
-public:
-    AtomicUInt32() : m_val(0) {}
-    AtomicUInt32(uint32_t v) : m_val(v) {}
-
-    operator uint32_t() const
-    {
-        return (uint32_t)ATOMIC_OR(&m_val, 0);
-    }
-
-    AtomicUInt32& operator=(uint32_t v)
-    {
-        ATOMIC_STORE(&m_val, (int32_t)v);
-        return *this;
-    }
-
-    uint32_t operator++()
-    {
-        return (uint32_t)ATOMIC_INC(&m_val);
-    }
-
-    uint32_t fetchAdd(uint32_t v)
-    {
-        return (uint32_t)ATOMIC_ADD(&m_val, (int32_t)v);
-    }
-
-private:
-    AtomicUInt32(const AtomicUInt32&);
-    AtomicUInt32& operator=(const AtomicUInt32&);
     mutable volatile int32_t m_val;
 };
 

--- a/source/common/threading.h
+++ b/source/common/threading.h
@@ -63,13 +63,13 @@ int64_t no_atomic_add64(int64_t* ptr, int64_t val);
 #define BSF(id, x)            (id) = ((unsigned long)__builtin_ctz(x))
 #define BSR64(id, x)          (id) = ((unsigned long)__builtin_clzll(x) ^ 63)
 #define BSF64(id, x)          (id) = ((unsigned long)__builtin_ctzll(x))
-#define ATOMIC_OR(ptr, mask)  no_atomic_or((int*)ptr, mask)
-#define ATOMIC_AND(ptr, mask) no_atomic_and((int*)ptr, mask)
-#define ATOMIC_INC(ptr)       no_atomic_inc((int*)ptr)
-#define ATOMIC_DEC(ptr)       no_atomic_dec((int*)ptr)
+#define ATOMIC_OR(ptr, mask)  no_atomic_or(const_cast<int*>(reinterpret_cast<volatile int*>(ptr)), mask)
+#define ATOMIC_AND(ptr, mask) no_atomic_and(const_cast<int*>(reinterpret_cast<volatile int*>(ptr)), mask)
+#define ATOMIC_INC(ptr)       no_atomic_inc(const_cast<int*>(reinterpret_cast<volatile int*>(ptr)))
+#define ATOMIC_DEC(ptr)       no_atomic_dec(const_cast<int*>(reinterpret_cast<volatile int*>(ptr)))
 #define ATOMIC_ADD(ptr, val)  (sizeof(*(ptr)) == 8 ? \
-                               no_atomic_add64((int64_t*)ptr, (int64_t)(val)) : \
-                               no_atomic_add((int*)ptr, (int)(val)))
+                               no_atomic_add64(const_cast<int64_t*>(reinterpret_cast<volatile int64_t*>(ptr)), (int64_t)(val)) : \
+                               no_atomic_add(const_cast<int*>(reinterpret_cast<volatile int*>(ptr)), (int)(val)))
 #define ATOMIC_STORE(ptr, val)    (*(ptr) = (int)(val))
 #define ATOMIC64_LOAD(ptr)        (*(ptr))
 #define ATOMIC64_STORE(ptr, val)  (*(ptr) = (val))
@@ -87,13 +87,13 @@ int64_t no_atomic_add64(int64_t* ptr, int64_t val);
 #define BSF64(id, x)          (id) = ((unsigned long)__builtin_ctzll(x))
 #define ATOMIC_OR(ptr, mask)  __sync_fetch_and_or(ptr, mask)
 #define ATOMIC_AND(ptr, mask) __sync_fetch_and_and(ptr, mask)
-#define ATOMIC_INC(ptr)       __sync_add_and_fetch((volatile int32_t*)ptr, 1)
-#define ATOMIC_DEC(ptr)       __sync_add_and_fetch((volatile int32_t*)ptr, -1)
-#define ATOMIC_ADD(ptr, val)  __sync_fetch_and_add((volatile __typeof__(*(ptr))*)ptr, (__typeof__(*(ptr) + 0))(val))
-#define ATOMIC_STORE(ptr, val)    __sync_lock_test_and_set((volatile int32_t*)ptr, (int32_t)(val))
-#define ATOMIC64_LOAD(ptr)        __sync_fetch_and_add((volatile int64_t*)ptr, 0)
-#define ATOMIC64_STORE(ptr, val)  __sync_lock_test_and_set((volatile int64_t*)ptr, val)
-#define ATOMIC64_ADD(ptr, val)    __sync_fetch_and_add((volatile int64_t*)ptr, val)
+#define ATOMIC_INC(ptr)       __sync_add_and_fetch(reinterpret_cast<volatile int32_t*>(ptr), 1)
+#define ATOMIC_DEC(ptr)       __sync_add_and_fetch(reinterpret_cast<volatile int32_t*>(ptr), -1)
+#define ATOMIC_ADD(ptr, val)  __sync_fetch_and_add(reinterpret_cast<volatile __typeof__(*(ptr))*>(ptr), (__typeof__(*(ptr) + 0))(val))
+#define ATOMIC_STORE(ptr, val)    __sync_lock_test_and_set(reinterpret_cast<volatile int32_t*>(ptr), (int32_t)(val))
+#define ATOMIC64_LOAD(ptr)        __sync_fetch_and_add(reinterpret_cast<volatile int64_t*>(ptr), 0)
+#define ATOMIC64_STORE(ptr, val)  __sync_lock_test_and_set(reinterpret_cast<volatile int64_t*>(ptr), val)
+#define ATOMIC64_ADD(ptr, val)    __sync_fetch_and_add(reinterpret_cast<volatile int64_t*>(ptr), val)
 #define GIVE_UP_TIME()        usleep(0)
 
 #elif defined(_MSC_VER)       /* Windows atomic intrinsics */
@@ -104,17 +104,17 @@ int64_t no_atomic_add64(int64_t* ptr, int64_t val);
 #define BSF(id, x)            _BitScanForward(&id, x)
 #define BSR64(id, x)          _BitScanReverse64(&id, x)
 #define BSF64(id, x)          _BitScanForward64(&id, x)
-#define ATOMIC_INC(ptr)       InterlockedIncrement((volatile LONG*)ptr)
-#define ATOMIC_DEC(ptr)       InterlockedDecrement((volatile LONG*)ptr)
+#define ATOMIC_INC(ptr)       InterlockedIncrement(reinterpret_cast<volatile LONG*>(ptr))
+#define ATOMIC_DEC(ptr)       InterlockedDecrement(reinterpret_cast<volatile LONG*>(ptr))
 #define ATOMIC_ADD(ptr, val)  (sizeof(*(ptr)) == 8 ? \
-                               InterlockedExchangeAdd64((volatile LONGLONG*)ptr, (LONGLONG)(val)) : \
-                               InterlockedExchangeAdd((volatile LONG*)ptr, (LONG)(val)))
-#define ATOMIC_OR(ptr, mask)  _InterlockedOr((volatile LONG*)ptr, (LONG)mask)
-#define ATOMIC_AND(ptr, mask) _InterlockedAnd((volatile LONG*)ptr, (LONG)mask)
-#define ATOMIC_STORE(ptr, val)    InterlockedExchange((volatile LONG*)ptr, (LONG)(val))
-#define ATOMIC64_LOAD(ptr)        InterlockedAdd64((volatile LONG64*)ptr, 0)
-#define ATOMIC64_STORE(ptr, val)  InterlockedExchange64((volatile LONG64*)ptr, val)
-#define ATOMIC64_ADD(ptr, val)    InterlockedAdd64((volatile LONG64*)ptr, val)
+                               InterlockedExchangeAdd64(reinterpret_cast<volatile LONGLONG*>(ptr), (LONGLONG)(val)) : \
+                               InterlockedExchangeAdd(reinterpret_cast<volatile LONG*>(ptr), (LONG)(val)))
+#define ATOMIC_OR(ptr, mask)  _InterlockedOr(reinterpret_cast<volatile LONG*>(ptr), static_cast<LONG>(mask))
+#define ATOMIC_AND(ptr, mask) _InterlockedAnd(reinterpret_cast<volatile LONG*>(ptr), static_cast<LONG>(mask))
+#define ATOMIC_STORE(ptr, val)    InterlockedExchange(reinterpret_cast<volatile LONG*>(ptr), (LONG)(val))
+#define ATOMIC64_LOAD(ptr)        InterlockedAdd64(reinterpret_cast<volatile LONG64*>(ptr), 0)
+#define ATOMIC64_STORE(ptr, val)  InterlockedExchange64(reinterpret_cast<volatile LONG64*>(ptr), val)
+#define ATOMIC64_ADD(ptr, val)    InterlockedAdd64(reinterpret_cast<volatile LONG64*>(ptr), val)
 #define GIVE_UP_TIME()        Sleep(0)
 
 #endif // ifdef __GNUC__
@@ -835,6 +835,10 @@ public:
     /* Copy-construct as a fresh unlocked instance — the lock state itself
      * must never be copied (same semantics as std::mutex). */
     SpinLock(const SpinLock&) : m_val(0) {}
+    /* Intentionally does not touch m_val: copying another instance's lock
+     * state into this one would be a real bug, not the omission cppcheck
+     * suspects (see class comment above). */
+    // cppcheck-suppress operatorEqVarError
     SpinLock& operator=(const SpinLock&) { return *this; }
 
     void acquire()
@@ -855,7 +859,7 @@ private:
 class ScopedSpinLock
 {
 public:
-    ScopedSpinLock(SpinLock& instance) : inst(instance) { inst.acquire(); }
+    explicit ScopedSpinLock(SpinLock& instance) : inst(instance) { inst.acquire(); }
     ~ScopedSpinLock() { inst.release(); }
 
 protected:
@@ -918,7 +922,7 @@ class Atomic
 
 public:
     Atomic() : m_val(0) {}
-    Atomic(T v) : m_val((Storage)v) {}
+    explicit Atomic(T v) : m_val((Storage)v) {}
 
     operator T() const          { return (T)Ops::load(&m_val); }
 
@@ -950,7 +954,7 @@ class AtomicDouble
 {
 public:
     AtomicDouble() : m_val(0) {}
-    AtomicDouble(double v) { store(v); }
+    explicit AtomicDouble(double v) : m_val(0) { store(v); }
 
     double load() const
     {
@@ -981,7 +985,7 @@ class AtomicBool
 {
 public:
     AtomicBool() : m_val(0) {}
-    AtomicBool(bool v) : m_val(v ? 1 : 0) {}
+    explicit AtomicBool(bool v) : m_val(v ? 1 : 0) {}
 
     operator bool() const
     {

--- a/source/common/threadpool.cpp
+++ b/source/common/threadpool.cpp
@@ -158,16 +158,16 @@ void WorkerThread::threadMain()
             /* if the current job provider still wants help, only switch to a
              * higher priority provider (lower slice type). Else take the first
              * available job provider with the highest priority */
-            int curPriority = (m_curJobProvider->m_helpWanted) ? m_curJobProvider->m_sliceType :
+            int curPriority = (bool)m_curJobProvider->m_helpWanted ? m_curJobProvider->m_sliceType.get() :
                                                                  INVALID_SLICE_PRIORITY + 1;
             int nextProvider = -1;
             for (int i = 0; i < m_pool.m_numProviders; i++)
             {
-                if (m_pool.m_jpTable[i]->m_helpWanted &&
-                    m_pool.m_jpTable[i]->m_sliceType < curPriority)
+                if ((bool)m_pool.m_jpTable[i]->m_helpWanted &&
+                    m_pool.m_jpTable[i]->m_sliceType.get() < curPriority)
                 {
                     nextProvider = i;
-                    curPriority = m_pool.m_jpTable[i]->m_sliceType;
+                    curPriority = m_pool.m_jpTable[i]->m_sliceType.get();
                 }
             }
             if (nextProvider != -1 && m_curJobProvider != m_pool.m_jpTable[nextProvider])
@@ -191,7 +191,7 @@ void WorkerThread::threadMain()
 
 void JobProvider::tryWakeOne()
 {
-    int id = m_pool->tryAcquireSleepingThread(m_ownerBitmap, ALL_POOL_THREADS);
+    int id = m_pool->tryAcquireSleepingThread(SLEEPBITMAP_LOAD(&m_ownerBitmap), ALL_POOL_THREADS);
     if (id < 0)
     {
         m_helpWanted = true;
@@ -213,7 +213,7 @@ int ThreadPool::tryAcquireSleepingThread(sleepbitmap_t firstTryBitmap, sleepbitm
 {
     unsigned long id;
 
-    sleepbitmap_t masked = m_sleepBitmap & firstTryBitmap;
+    sleepbitmap_t masked = SLEEPBITMAP_LOAD(&m_sleepBitmap) & firstTryBitmap;
     while (masked)
     {
         SLEEPBITMAP_BSF(id, masked);
@@ -222,10 +222,10 @@ int ThreadPool::tryAcquireSleepingThread(sleepbitmap_t firstTryBitmap, sleepbitm
         if (SLEEPBITMAP_AND(&m_sleepBitmap, ~bit) & bit)
             return (int)id;
 
-        masked = m_sleepBitmap & firstTryBitmap;
+        masked = SLEEPBITMAP_LOAD(&m_sleepBitmap) & firstTryBitmap;
     }
 
-    masked = m_sleepBitmap & secondTryBitmap;
+    masked = SLEEPBITMAP_LOAD(&m_sleepBitmap) & secondTryBitmap;
     while (masked)
     {
         SLEEPBITMAP_BSF(id, masked);
@@ -234,7 +234,7 @@ int ThreadPool::tryAcquireSleepingThread(sleepbitmap_t firstTryBitmap, sleepbitm
         if (SLEEPBITMAP_AND(&m_sleepBitmap, ~bit) & bit)
             return (int)id;
 
-        masked = m_sleepBitmap & secondTryBitmap;
+        masked = SLEEPBITMAP_LOAD(&m_sleepBitmap) & secondTryBitmap;
     }
 
     return -1;
@@ -725,7 +725,7 @@ void ThreadPool::stopWorkers()
         m_isActive = false;
         for (int i = 0; i < m_numWorkers; i++)
         {
-            while (!(m_sleepBitmap & ((sleepbitmap_t)1 << i)))
+            while (!(SLEEPBITMAP_LOAD(&m_sleepBitmap) & ((sleepbitmap_t)1 << i)))
                 GIVE_UP_TIME();
             m_workers[i].awaken();
             m_workers[i].stop();

--- a/source/common/threadpool.h
+++ b/source/common/threadpool.h
@@ -39,7 +39,8 @@ typedef uint64_t sleepbitmap_t;
 #ifdef __GNUC__
 #define SLEEPBITMAP_LOAD(ptr) __sync_fetch_and_or(ptr, 0)
 #elif defined(_MSC_VER)
-#define SLEEPBITMAP_LOAD(ptr) InterlockedOr64((volatile LONG64*)ptr, 0)
+/* LONG64 vs. uint64_t signedness mismatch is intentional: InterlockedOr64 only needs the bit pattern */
+#define SLEEPBITMAP_LOAD(ptr) InterlockedOr64(reinterpret_cast<volatile LONG64*>(ptr), 0)
 #endif
 #else
 typedef uint32_t sleepbitmap_t;

--- a/source/common/threadpool.h
+++ b/source/common/threadpool.h
@@ -60,8 +60,8 @@ public:
     ThreadPool*   m_pool;
     sleepbitmap_t m_ownerBitmap;
     int           m_jpId;
-    ThreadSafeInteger           m_sliceType;
-    AtomicInt32          m_helpWanted;
+    ThreadSafeInteger m_sliceType;
+    AtomicInt32   m_helpWanted;
     bool          m_isFrameEncoder; /* rather ugly hack, but nothing better presents itself */
 
     JobProvider()

--- a/source/common/threadpool.h
+++ b/source/common/threadpool.h
@@ -36,8 +36,15 @@ class BondedTaskGroup;
 
 #if X86_64 || X265_ARCH_ARM64
 typedef uint64_t sleepbitmap_t;
+#ifdef __GNUC__
+#define SLEEPBITMAP_LOAD(ptr) __sync_fetch_and_or(ptr, 0)
+#elif defined(_MSC_VER)
+#define SLEEPBITMAP_LOAD(ptr) InterlockedOr64((volatile LONG64*)ptr, 0)
+#endif
 #else
 typedef uint32_t sleepbitmap_t;
+/* use 32-bit primitives defined in threading.h */
+#define SLEEPBITMAP_LOAD(ptr) ATOMIC_OR(ptr, 0)
 #endif
 
 static const sleepbitmap_t ALL_POOL_THREADS = (sleepbitmap_t)-1;
@@ -53,18 +60,19 @@ public:
     ThreadPool*   m_pool;
     sleepbitmap_t m_ownerBitmap;
     int           m_jpId;
-    int           m_sliceType;
-    bool          m_helpWanted;
+    ThreadSafeInteger           m_sliceType;
+    AtomicInt32          m_helpWanted;
     bool          m_isFrameEncoder; /* rather ugly hack, but nothing better presents itself */
 
     JobProvider()
         : m_pool(NULL)
         , m_ownerBitmap(0)
         , m_jpId(-1)
-        , m_sliceType(INVALID_SLICE_PRIORITY)
         , m_helpWanted(false)
         , m_isFrameEncoder(false)
-    {}
+    {
+        m_sliceType.set(INVALID_SLICE_PRIORITY);
+    }
 
     virtual ~JobProvider() {}
 
@@ -87,7 +95,7 @@ public:
 #if defined(_WIN32_WINNT) && _WIN32_WINNT >= _WIN32_WINNT_WIN7 
     GROUP_AFFINITY m_groupAffinity;
 #endif
-    bool          m_isActive;
+    AtomicBool           m_isActive;
 
     JobProvider** m_jpTable;
     WorkerThread* m_workers;
@@ -141,7 +149,7 @@ public:
      * maxPeers worker threads will call your processTasks() method. */
     int tryBondPeers(JobProvider& jp, int maxPeers)
     {
-        int count = jp.m_pool->tryBondPeers(maxPeers, jp.m_ownerBitmap, *this);
+        int count = jp.m_pool->tryBondPeers(maxPeers, SLEEPBITMAP_LOAD(&jp.m_ownerBitmap), *this);
         m_bondedPeerCount += count;
         return count;
     }

--- a/source/common/wavefront.cpp
+++ b/source/common/wavefront.cpp
@@ -65,8 +65,11 @@ void WaveFront::setLayerId(int layer)
 
 void WaveFront::clearEnabledRowMask()
 {
-    memset((void*)m_externalDependencyBitmap, 0, sizeof(uint32_t) * m_numWords);
-    memset((void*)m_internalDependencyBitmap, 0, sizeof(uint32_t) * m_numWords);
+    for (int i = 0; i < m_numWords; i++)
+    {
+        ATOMIC_AND(&m_externalDependencyBitmap[i], 0);
+        ATOMIC_AND(&m_internalDependencyBitmap[i], 0);
+    }
 }
 
 void WaveFront::enqueueRow(int row)
@@ -83,7 +86,8 @@ void WaveFront::enableRow(int row)
 
 void WaveFront::enableAllRows()
 {
-    memset((void*)m_externalDependencyBitmap, ~0, sizeof(uint32_t) * m_numWords);
+    for (int i = 0; i < m_numWords; i++)
+        ATOMIC_OR(&m_externalDependencyBitmap[i], 0xFFFFFFFF);
 }
 
 bool WaveFront::dequeueRow(int row)
@@ -99,7 +103,7 @@ void WaveFront::findJob(int threadId)
     /* Loop over each word until all available rows are finished */
     for (int w = 0; w < m_numWords; w++)
     {
-        uint32_t oldval = m_internalDependencyBitmap[w] & m_externalDependencyBitmap[w];
+        uint32_t oldval = ATOMIC_OR(&m_internalDependencyBitmap[w], 0) & ATOMIC_OR(&m_externalDependencyBitmap[w], 0);
         while (oldval)
         {
             BSF(id, oldval);
@@ -113,7 +117,7 @@ void WaveFront::findJob(int threadId)
                 return; /* check for a higher priority task */
             }
 
-            oldval = m_internalDependencyBitmap[w] & m_externalDependencyBitmap[w];
+            oldval = ATOMIC_OR(&m_internalDependencyBitmap[w], 0) & ATOMIC_OR(&m_externalDependencyBitmap[w], 0);
         }
     }
 

--- a/source/encoder/analysis.cpp
+++ b/source/encoder/analysis.cpp
@@ -4120,6 +4120,7 @@ uint32_t Analysis::topSkipMinDepth(const CUData& parentCTU, const CUGeom& cuGeom
     {
         numRefs++;
         const CUData& cu = *m_slice->m_refFrameList[0][0]->m_encData->getPicCTU(parentCTU.m_cuAddr);
+        ScopedLock lock(cu.m_accessLock);
         previousQP = cu.m_qp[0];
         if (!cu.m_cuDepth[cuGeom.absPartIdx])
             return 0;

--- a/source/encoder/analysis.cpp
+++ b/source/encoder/analysis.cpp
@@ -4120,7 +4120,7 @@ uint32_t Analysis::topSkipMinDepth(const CUData& parentCTU, const CUGeom& cuGeom
     {
         numRefs++;
         const CUData& cu = *m_slice->m_refFrameList[0][0]->m_encData->getPicCTU(parentCTU.m_cuAddr);
-        ScopedLock lock(cu.m_accessLock);
+        ScopedSpinLock lock(cu.m_accessLock);
         previousQP = cu.m_qp[0];
         if (!cu.m_cuDepth[cuGeom.absPartIdx])
             return 0;

--- a/source/encoder/dpb.cpp
+++ b/source/encoder/dpb.cpp
@@ -80,8 +80,6 @@ void DPB::recycleUnreferenced()
 
         if (curFrame->m_valid && !curFrame->m_encData->m_bHasReferences && !curFrame->m_countRefEncoders && !isMCSTFReferenced)
         {
-            curFrame->m_bChromaExtended = false;
-
             if (curFrame->m_param->bEnableTemporalFilter)
                 *curFrame->m_isSubSampled = false;
 

--- a/source/encoder/encoder.cpp
+++ b/source/encoder/encoder.cpp
@@ -40,6 +40,7 @@
 #include "dpb.h"
 #include "nal.h"
 #include "threadedme.h"
+#include "ratecontrol.h"
 
 #include "x265.h"
 
@@ -1053,7 +1054,13 @@ void Encoder::updateVbvPlan(RateControl* rc)
         FrameEncoder *encoder = m_frameEncoder[i];
         if (encoder->m_rce.isActive && encoder->m_rce.poc != rc->m_curSlice->m_poc)
         {
-            int64_t bits = m_param->rc.bEnableConstVbv ? (int64_t)encoder->m_rce.frameSizePlanned : (int64_t)X265_MAX(encoder->m_rce.frameSizeEstimated, encoder->m_rce.frameSizePlanned);
+            double frameSizeEst, frameSizePlan;
+            {
+                ScopedLock lock(encoder->m_rce.m_rateControlEntryLock);
+                frameSizeEst  = encoder->m_rce.frameSizeEstimated;
+                frameSizePlan = encoder->m_rce.frameSizePlanned;
+            }
+            int64_t bits = m_param->rc.bEnableConstVbv ? (int64_t)frameSizePlan : (int64_t)X265_MAX(frameSizeEst, frameSizePlan);
             rc->m_bufferFill -= bits;
             rc->m_bufferFill = X265_MAX(rc->m_bufferFill, 0);
             rc->m_bufferFill += encoder->m_rce.bufferRate;
@@ -3208,8 +3215,11 @@ void Encoder::finishFrameStats(Frame* curFrame, FrameEncoder *curEncoder, x265_f
         frameStats->bScenecut = curFrame->m_lowres.bScenecut;
         if (m_param->csvLogLevel >= 2)
             frameStats->ipCostRatio = curFrame->m_lowres.ipCostRatio;
-        frameStats->bufferFill = m_rateControl->m_bufferFillActual;
-        frameStats->bufferFillFinal = m_rateControl->m_bufferFillFinal;
+        {
+            ScopedLock lock(m_rateControl->m_rateControlLock);
+            frameStats->bufferFill = m_rateControl->m_bufferFillActual;
+            frameStats->bufferFillFinal = m_rateControl->m_bufferFillFinal;
+        }
         if (m_param->csvLogLevel >= 2)
             frameStats->unclippedBufferFillFinal = m_rateControl->m_unclippedBufferFillFinal;
         frameStats->frameLatency = inPoc - poc;

--- a/source/encoder/encoder.cpp
+++ b/source/encoder/encoder.cpp
@@ -1902,6 +1902,20 @@ int Encoder::encode(const x265_picture* pic_in, x265_picture* pic_out)
         if (m_reconfigureRc || m_param->bConfigRCFrame)
             inFrame[0]->m_reconfigureRc = true;
 
+        /* Extend chroma borders unconditionally, before this frame can be
+         * referenced by any other frame encoder thread. This replaces the
+         * lazy, flag-guarded extension that used to happen inside
+         * weightAnalyse(), which raced with compressCTU() reading the same
+         * buffer on another thread with no synchronization between them. */
+        if (m_param->internalCsp != X265_CSP_I400)
+        {
+            PicYuv *orig = inFrame[0]->m_fencPic;
+            int width  = orig->m_picWidth  >> orig->m_hChromaShift;
+            int height = orig->m_picHeight >> orig->m_vChromaShift;
+            extendPicBorder(orig->m_picOrg[1], orig->m_strideC, width, height, orig->m_chromaMarginX, orig->m_chromaMarginY);
+            extendPicBorder(orig->m_picOrg[2], orig->m_strideC, width, height, orig->m_chromaMarginX, orig->m_chromaMarginY);
+        }
+
         if (m_param->bEnableTemporalFilter)
         {
             if (!m_pocLast)
@@ -1945,11 +1959,9 @@ int Encoder::encode(const x265_picture* pic_in, x265_picture* pic_out)
             if (m_param->totalFrames && (inFrame[0]->m_poc >= (m_param->totalFrames - inFrame[0]->m_mcstf->m_range)))
                 inFrame[0]->m_refPicCnt[1] -= (uint8_t)(inFrame[0]->m_poc + inFrame[0]->m_mcstf->m_range - m_param->totalFrames + 1);
 
-            //Extend full-res original picture border
+            //Extend full-res original picture luma border (chroma already extended above)
             PicYuv *orig = inFrame[0]->m_fencPic;
             extendPicBorder(orig->m_picOrg[0], orig->m_stride, orig->m_picWidth, orig->m_picHeight, orig->m_lumaMarginX, orig->m_lumaMarginY);
-            extendPicBorder(orig->m_picOrg[1], orig->m_strideC, orig->m_picWidth >> orig->m_hChromaShift, orig->m_picHeight >> orig->m_vChromaShift, orig->m_chromaMarginX, orig->m_chromaMarginY);
-            extendPicBorder(orig->m_picOrg[2], orig->m_strideC, orig->m_picWidth >> orig->m_hChromaShift, orig->m_picHeight >> orig->m_vChromaShift, orig->m_chromaMarginX, orig->m_chromaMarginY);
 
             //TODO: Add subsampling here if required
             inFrame[0]->m_mcstffencPic->copyFromFrame(inFrame[0]->m_fencPic);

--- a/source/encoder/encoder.cpp
+++ b/source/encoder/encoder.cpp
@@ -1054,12 +1054,8 @@ void Encoder::updateVbvPlan(RateControl* rc)
         FrameEncoder *encoder = m_frameEncoder[i];
         if (encoder->m_rce.isActive && encoder->m_rce.poc != rc->m_curSlice->m_poc)
         {
-            double frameSizeEst, frameSizePlan;
-            {
-                ScopedLock lock(encoder->m_rce.m_rateControlEntryLock);
-                frameSizeEst  = encoder->m_rce.frameSizeEstimated;
-                frameSizePlan = encoder->m_rce.frameSizePlanned;
-            }
+            double frameSizeEst = encoder->m_rce.frameSizeEstimated;
+            double frameSizePlan = encoder->m_rce.frameSizePlanned;
             int64_t bits = m_param->rc.bEnableConstVbv ? (int64_t)frameSizePlan : (int64_t)X265_MAX(frameSizeEst, frameSizePlan);
             rc->m_bufferFill -= bits;
             rc->m_bufferFill = X265_MAX(rc->m_bufferFill, 0);
@@ -3215,11 +3211,8 @@ void Encoder::finishFrameStats(Frame* curFrame, FrameEncoder *curEncoder, x265_f
         frameStats->bScenecut = curFrame->m_lowres.bScenecut;
         if (m_param->csvLogLevel >= 2)
             frameStats->ipCostRatio = curFrame->m_lowres.ipCostRatio;
-        {
-            ScopedLock lock(m_rateControl->m_rateControlLock);
-            frameStats->bufferFill = m_rateControl->m_bufferFillActual;
-            frameStats->bufferFillFinal = m_rateControl->m_bufferFillFinal;
-        }
+        frameStats->bufferFill = m_rateControl->m_bufferFillActual;
+        frameStats->bufferFillFinal = m_rateControl->m_bufferFillFinal;
         if (m_param->csvLogLevel >= 2)
             frameStats->unclippedBufferFillFinal = m_rateControl->m_unclippedBufferFillFinal;
         frameStats->frameLatency = inPoc - poc;

--- a/source/encoder/encoder.cpp
+++ b/source/encoder/encoder.cpp
@@ -636,9 +636,6 @@ void Encoder::stopJobs()
     if (m_lookahead)
         m_lookahead->stopJobs();
 
-    if (m_threadedME)
-        m_threadedME->stopJobs();
-
     for (int i = 0; i < m_param->frameNumThreads; i++)
     {
         if (m_frameEncoder[i])
@@ -649,6 +646,9 @@ void Encoder::stopJobs()
             m_frameEncoder[i]->stop();
         }
     }
+
+    if (m_threadedME)
+        m_threadedME->stopJobs();
 
     if (m_threadPool)
     {

--- a/source/encoder/frameencoder.cpp
+++ b/source/encoder/frameencoder.cpp
@@ -1678,11 +1678,8 @@ void FrameEncoder::processRowEncoder(int intRow, ThreadLocalData& tld, int layer
             }
             if (bFirstRowInSlice && m_vbvResetTriggerRow[curRow.sliceId] != intRow)
             {
-                {
-                    ScopedLock lock(curEncData.m_rowStatLock);
-                    curEncData.m_rowStat[row].rowQp = curEncData.m_avgQpRc;
-                    curEncData.m_rowStat[row].rowQpScale = x265_qp2qScale(curEncData.m_avgQpRc);
-                }
+                curEncData.m_rowStat[row].rowQp = curEncData.m_avgQpRc;
+                curEncData.m_rowStat[row].rowQpScale = x265_qp2qScale(curEncData.m_avgQpRc);
             }
 
             FrameData::RCStatCU& cuStat = curEncData.m_cuStat[cuAddr];
@@ -1793,7 +1790,7 @@ void FrameEncoder::processRowEncoder(int intRow, ThreadLocalData& tld, int layer
         }
 
         // Completed CU processing
-        ++curRow.completed;
+        curRow.completed++;
 
         FrameStats frameLog;
         curEncData.m_rowStat[row].sumQpAq += collectCTUStatistics(*ctu, &frameLog);
@@ -1908,11 +1905,8 @@ void FrameEncoder::processRowEncoder(int intRow, ThreadLocalData& tld, int layer
                 double qpBase = curEncData.m_cuStat[cuAddr].baseQp;
                 curRow.reEncode = m_top->m_rateControl->rowVbvRateControl(m_frame[layer], row, &m_rce, qpBase, m_sliceBaseRow, sliceId);
                 qpBase = x265_clip3((double)m_param->rc.qpMin, (double)m_param->rc.qpMax, qpBase);
-                {
-                    ScopedLock lock(curEncData.m_rowStatLock);
-                    curEncData.m_rowStat[row].rowQp = qpBase;
-                    curEncData.m_rowStat[row].rowQpScale = x265_qp2qScale(qpBase);
-                }
+                curEncData.m_rowStat[row].rowQp = qpBase;
+                curEncData.m_rowStat[row].rowQpScale = x265_qp2qScale(qpBase);
                 if (curRow.reEncode < 0)
                 {
                     x265_log(m_param, X265_LOG_DEBUG, "POC %d row %d - encode restart required for VBV, to %.2f from %.2f\n",

--- a/source/encoder/frameencoder.cpp
+++ b/source/encoder/frameencoder.cpp
@@ -283,7 +283,7 @@ bool FrameEncoder::startCompressFrame(Frame* curFrame[MAX_LAYERS])
         curFrame[layer]->m_encData->m_jobProvider = this;
         curFrame[layer]->m_encData->m_slice->m_mref = m_mref;
     }
-    m_sliceType = curFrame[0]->m_lowres.sliceType;
+    m_sliceType.set(curFrame[0]->m_lowres.sliceType);
 
     if (!m_cuGeoms)
     {
@@ -1489,8 +1489,8 @@ void FrameEncoder::encodeSlice(uint32_t sliceAddr, int layer)
 void FrameEncoder::processRow(int row, int threadId, int layer)
 {
     int64_t startTime = x265_mdate();
-    if (ATOMIC_INC(&m_activeWorkerCount) == 1 && m_stallStartTime[layer])
-        m_totalNoWorkerTime[layer] += x265_mdate() - m_stallStartTime[layer];
+    if (++m_activeWorkerCount == 1 && m_stallStartTime[layer])
+        m_totalNoWorkerTime[layer].add(x265_mdate() - m_stallStartTime[layer]);
 
     const uint32_t realRow = m_idx_to_row[row >> 1];
     const uint32_t typeNum = m_idx_to_row[row & 1];
@@ -1508,10 +1508,10 @@ void FrameEncoder::processRow(int row, int threadId, int layer)
             enqueueRowFilter(m_row_to_idx[realRow + 1]);
     }
 
-    if (ATOMIC_DEC(&m_activeWorkerCount) == 0)
+    if (--m_activeWorkerCount == 0)
         m_stallStartTime[layer] = x265_mdate();
 
-    m_totalWorkerElapsedTime[layer] += x265_mdate() - startTime; // not thread safe, but good enough
+    m_totalWorkerElapsedTime[layer].add(x265_mdate() - startTime);
 }
 
 // Called by worker threads
@@ -1678,8 +1678,11 @@ void FrameEncoder::processRowEncoder(int intRow, ThreadLocalData& tld, int layer
             }
             if (bFirstRowInSlice && m_vbvResetTriggerRow[curRow.sliceId] != intRow)
             {
-                curEncData.m_rowStat[row].rowQp = curEncData.m_avgQpRc;
-                curEncData.m_rowStat[row].rowQpScale = x265_qp2qScale(curEncData.m_avgQpRc);
+                {
+                    ScopedLock lock(curEncData.m_rowStatLock);
+                    curEncData.m_rowStat[row].rowQp = curEncData.m_avgQpRc;
+                    curEncData.m_rowStat[row].rowQpScale = x265_qp2qScale(curEncData.m_avgQpRc);
+                }
             }
 
             FrameData::RCStatCU& cuStat = curEncData.m_cuStat[cuAddr];
@@ -1732,7 +1735,7 @@ void FrameEncoder::processRowEncoder(int intRow, ThreadLocalData& tld, int layer
             collectDynDataRow(*ctu, &curRow.rowStats);
 
         // take a sample of the current active worker count
-        ATOMIC_ADD(&m_totalActiveWorkerCount, m_activeWorkerCount);
+        m_totalActiveWorkerCount.fetchAdd(m_activeWorkerCount);
         ATOMIC_INC(&m_activeWorkerCountSamples);
 
         /* advance top-level row coder to include the context of this CTU.
@@ -1790,7 +1793,7 @@ void FrameEncoder::processRowEncoder(int intRow, ThreadLocalData& tld, int layer
         }
 
         // Completed CU processing
-        curRow.completed++;
+        ++curRow.completed;
 
         FrameStats frameLog;
         curEncData.m_rowStat[row].sumQpAq += collectCTUStatistics(*ctu, &frameLog);
@@ -1842,9 +1845,9 @@ void FrameEncoder::processRowEncoder(int intRow, ThreadLocalData& tld, int layer
             FrameData::RCStatCU& cuStat = curEncData.m_cuStat[cuAddr];    
             if ((m_param->bEnableWavefront && ((cuAddr == m_sliceBaseRow[sliceId] * numCols) || !m_param->rc.bEnableConstVbv)) || !m_param->bEnableWavefront)
             {
-                curEncData.m_rowStat[row].rowSatd += cuStat.vbvCost;
-                curEncData.m_rowStat[row].rowIntraSatd += cuStat.intraVbvCost;
-                curEncData.m_rowStat[row].encodedBits += cuStat.totalBits;
+                curEncData.m_rowStat[row].rowSatd.fetchAdd(cuStat.vbvCost);
+                curEncData.m_rowStat[row].rowIntraSatd.fetchAdd(cuStat.intraVbvCost);
+                curEncData.m_rowStat[row].encodedBits.fetchAdd(cuStat.totalBits);
                 curEncData.m_rowStat[row].sumQpRc += cuStat.baseQp;
                 curEncData.m_rowStat[row].numEncodedCUs = cuAddr;
             }
@@ -1890,9 +1893,9 @@ void FrameEncoder::processRowEncoder(int intRow, ThreadLocalData& tld, int layer
                     {
                         for (uint32_t c = startCuAddr; c <= EndCuAddr && c <= numCols * (r + 1) - 1; c++)
                         {
-                            curEncData.m_rowStat[r].rowSatd += curEncData.m_cuStat[c].vbvCost;
-                            curEncData.m_rowStat[r].rowIntraSatd += curEncData.m_cuStat[c].intraVbvCost;
-                            curEncData.m_rowStat[r].encodedBits += curEncData.m_cuStat[c].totalBits;
+                            curEncData.m_rowStat[r].rowSatd.fetchAdd(curEncData.m_cuStat[c].vbvCost);
+                            curEncData.m_rowStat[r].rowIntraSatd.fetchAdd(curEncData.m_cuStat[c].intraVbvCost);
+                            curEncData.m_rowStat[r].encodedBits.fetchAdd(curEncData.m_cuStat[c].totalBits);
                             curEncData.m_rowStat[r].sumQpRc += curEncData.m_cuStat[c].baseQp;
                             curEncData.m_rowStat[r].numEncodedCUs = c;
                         }
@@ -1905,9 +1908,11 @@ void FrameEncoder::processRowEncoder(int intRow, ThreadLocalData& tld, int layer
                 double qpBase = curEncData.m_cuStat[cuAddr].baseQp;
                 curRow.reEncode = m_top->m_rateControl->rowVbvRateControl(m_frame[layer], row, &m_rce, qpBase, m_sliceBaseRow, sliceId);
                 qpBase = x265_clip3((double)m_param->rc.qpMin, (double)m_param->rc.qpMax, qpBase);
-                curEncData.m_rowStat[row].rowQp = qpBase;
-                curEncData.m_rowStat[row].rowQpScale = x265_qp2qScale(qpBase);
-
+                {
+                    ScopedLock lock(curEncData.m_rowStatLock);
+                    curEncData.m_rowStat[row].rowQp = qpBase;
+                    curEncData.m_rowStat[row].rowQpScale = x265_qp2qScale(qpBase);
+                }
                 if (curRow.reEncode < 0)
                 {
                     x265_log(m_param, X265_LOG_DEBUG, "POC %d row %d - encode restart required for VBV, to %.2f from %.2f\n",
@@ -2005,9 +2010,9 @@ void FrameEncoder::processRowEncoder(int intRow, ThreadLocalData& tld, int layer
             {
                 for (uint32_t c = curEncData.m_rowStat[r].numEncodedCUs + 1; c < numCols * (r + 1); c++)
                 {
-                    curEncData.m_rowStat[r].rowSatd += curEncData.m_cuStat[c].vbvCost;
-                    curEncData.m_rowStat[r].rowIntraSatd += curEncData.m_cuStat[c].intraVbvCost;
-                    curEncData.m_rowStat[r].encodedBits += curEncData.m_cuStat[c].totalBits;
+                    curEncData.m_rowStat[r].rowSatd.fetchAdd(curEncData.m_cuStat[c].vbvCost);
+                    curEncData.m_rowStat[r].rowIntraSatd.fetchAdd(curEncData.m_cuStat[c].intraVbvCost);
+                    curEncData.m_rowStat[r].encodedBits.fetchAdd(curEncData.m_cuStat[c].totalBits);
                     curEncData.m_rowStat[r].sumQpRc += curEncData.m_cuStat[c].baseQp;
                     curEncData.m_rowStat[r].numEncodedCUs = c;
                 }

--- a/source/encoder/frameencoder.h
+++ b/source/encoder/frameencoder.h
@@ -77,7 +77,7 @@ struct CTURow
 {
     Entropy           bufferedEntropy;  /* store CTU2 context for next row CTU0 */
     Entropy           rowGoOnCoder;     /* store context between CTUs, code bitstream if !SAO */
-    unsigned int      sliceId;          /* store current row slice id */
+    AtomicUInt32      sliceId;          /* store current row slice id */
 
     FrameStats        rowStats;
 

--- a/source/encoder/frameencoder.h
+++ b/source/encoder/frameencoder.h
@@ -42,6 +42,7 @@
 #include "nal.h"
 #include "temporalfilter.h"
 #include "threadedme.h"
+#include "threading.h"
 #include <queue>
 
 namespace X265_NS {
@@ -97,7 +98,7 @@ struct CTURow
     volatile bool     busy;
 
     /* count of completed CUs in this row */
-    volatile uint32_t completed;
+    AtomicUInt32 completed;
     volatile uint32_t avgQPComputed;
 
     volatile int      reEncode;
@@ -229,8 +230,8 @@ public:
     uint64_t                 m_accessUnitBits[MAX_LAYERS];
     uint32_t                 m_ssimCnt[MAX_LAYERS];
 
-    volatile int             m_activeWorkerCount;        // count of workers currently encoding or filtering CTUs
-    volatile int             m_totalActiveWorkerCount;   // sum of m_activeWorkerCount sampled at end of each CTU
+    AtomicInt32              m_activeWorkerCount;        // count of workers currently encoding or filtering CTUs
+    AtomicInt32              m_totalActiveWorkerCount;   // sum of m_activeWorkerCount sampled at end of each CTU
     volatile int             m_activeWorkerCountSamples; // count of times m_activeWorkerCount was sampled (think vbv restarts)
     volatile int             m_countRowBlocks;           // count of workers forced to abandon a row because of top dependency
     int64_t                  m_startCompressTime[MAX_LAYERS];        // timestamp when frame encoder is given a frame
@@ -238,11 +239,11 @@ public:
     int64_t                  m_allRowsAvailableTime[MAX_LAYERS];     // timestamp when all reference dependencies are resolved
     int64_t                  m_endCompressTime[MAX_LAYERS];          // timestamp after all CTUs are compressed
     int64_t                  m_endFrameTime[MAX_LAYERS];             // timestamp after RCEnd, NR updates, etc
-    int64_t                  m_stallStartTime[MAX_LAYERS];           // timestamp when worker count becomes 0
+    AtomicInt64              m_stallStartTime[MAX_LAYERS];           // timestamp when worker count becomes 0
     int64_t                  m_prevOutputTime[MAX_LAYERS];           // timestamp when prev frame was retrieved by API thread
     int64_t                  m_slicetypeWaitTime[MAX_LAYERS];        // total elapsed time waiting for decided frame
-    int64_t                  m_totalWorkerElapsedTime[MAX_LAYERS];   // total elapsed time spent by worker threads processing CTUs
-    int64_t                  m_totalNoWorkerTime[MAX_LAYERS];        // total elapsed time without any active worker threads
+    AtomicInt64              m_totalWorkerElapsedTime[MAX_LAYERS];   // total elapsed time spent by worker threads processing CTUs
+    AtomicInt64              m_totalNoWorkerTime[MAX_LAYERS];        // total elapsed time without any active worker threads
     int64_t                  m_totalThreadedMEWait[MAX_LAYERS];      // total time spent waiting by CTUs for ThreadedME
     int64_t                  m_totalThreadedMETime[MAX_LAYERS];      // total time spent processing by ThreadedME
 

--- a/source/encoder/ratecontrol.cpp
+++ b/source/encoder/ratecontrol.cpp
@@ -433,7 +433,7 @@ void RateControl::initVBV(const SPS& sps)
         m_param->vbvEndFrameAdjust = x265_clip3(0.0, 1.0, m_param->vbvEndFrameAdjust);
     m_param->rc.vbvBufferInit = x265_clip3(0.0, 1.0, X265_MAX(m_param->rc.vbvBufferInit, m_bufferRate / m_bufferSize));
     m_bufferFillFinal = m_bufferSize * m_param->rc.vbvBufferInit;
-    m_bufferFillActual = m_bufferFillFinal;
+    m_bufferFillActual = double(m_bufferFillFinal);
     m_bufferExcess = 0;
     m_minBufferFill = m_param->minVbvFullness / 100;
     m_maxBufferFill = 1 - (m_param->maxVbvFullness / 100);
@@ -2820,10 +2820,7 @@ double RateControl::predictRowsSizeSum(Frame* curFrame, RateControlEntry* rce, d
                 }
 
                 refRowSatdCost >>= X265_DEPTH - 8;
-                {
-                    ScopedLock lock(refEncData.m_rowStatLock);
-                    refQScale = refEncData.m_rowStat[row].rowQpScale;
-                }
+                refQScale = refEncData.m_rowStat[row].rowQpScale;
             }
 
             if (picType == I_SLICE || qScale >= refQScale)
@@ -2922,11 +2919,8 @@ int RateControl::rowVbvRateControl(Frame* curFrame, uint32_t row, RateControlEnt
 
         double wantedBits;
         double totalBits;
-        {
-            ScopedLock lock(m_rateControlLock);
-            wantedBits = m_wantedBitsWindow;
-            totalBits = (double)(int64_t)m_totalBits;
-        }
+        wantedBits = m_wantedBitsWindow;
+        totalBits = (double)(int64_t)m_totalBits;
         double totalBitsNeeded = wantedBits;
         if (m_param->totalFrames)
             totalBitsNeeded = (m_param->totalFrames * m_bitrate) / m_fps;
@@ -2944,11 +2938,7 @@ int RateControl::rowVbvRateControl(Frame* curFrame, uint32_t row, RateControlEnt
             abrOvershoot = (accFrameBits + totalBits - wantedBits) / totalBitsNeeded;
         }
 
-        double row0Qp;
-        {
-            ScopedLock lock(curEncData.m_rowStatLock);
-            row0Qp = curEncData.m_rowStat[0].rowQp;
-        }
+        double row0Qp = curEncData.m_rowStat[0].rowQp;
         while (qpVbv > qpMin
                && (qpVbv > row0Qp || m_singleFrameVbv)
                && (((accFrameBits < rce->frameSizePlanned * 0.8f && qpVbv <= prevRowQp)
@@ -2988,10 +2978,7 @@ int RateControl::rowVbvRateControl(Frame* curFrame, uint32_t row, RateControlEnt
             accFrameBits = predictRowsSizeSum(curFrame, rce, qpVbv, encodedBitsSoFar);
         }
 
-        {
-            ScopedLock lock(rce->m_rateControlEntryLock);
-            rce->frameSizeEstimated = accFrameBits;
-        }
+        rce->frameSizeEstimated = accFrameBits;
         /* If the current row was large enough to cause a large QP jump, try re-encoding it. */
         if (qpVbv > qpMax && prevRowQp < qpMax && canReencodeRow)
         {
@@ -3012,10 +2999,7 @@ int RateControl::rowVbvRateControl(Frame* curFrame, uint32_t row, RateControlEnt
     else
     {
         int32_t encodedBitsSoFar = 0;
-        {
-            ScopedLock lock(rce->m_rateControlEntryLock);
-            rce->frameSizeEstimated = predictRowsSizeSum(curFrame, rce, qpVbv, encodedBitsSoFar);
-        }
+        rce->frameSizeEstimated = predictRowsSizeSum(curFrame, rce, qpVbv, encodedBitsSoFar);
 
         /* Last-ditch attempt: if the last row of the frame underflowed the VBV,
          * try again. */
@@ -3088,13 +3072,13 @@ int RateControl::updateVbv(int64_t bits, RateControlEntry* rce)
     if (!m_isVbv)
         return 0;
 
-    m_bufferFillFinal -= bits;
+    m_bufferFillFinal = double(m_bufferFillFinal) - bits;
 
     if (m_bufferFillFinal < 0)
-        x265_log(m_param, X265_LOG_WARNING, "poc:%d, VBV underflow (%.0f bits)\n", rce->poc, m_bufferFillFinal);
+        x265_log(m_param, X265_LOG_WARNING, "poc:%d, VBV underflow (%.0f bits)\n", rce->poc, (double)m_bufferFillFinal);
 
-    m_bufferFillFinal = X265_MAX(m_bufferFillFinal, 0);
-    m_bufferFillFinal += rce->bufferRate;
+    m_bufferFillFinal = X265_MAX(double(m_bufferFillFinal), 0.0);
+    m_bufferFillFinal = double(m_bufferFillFinal) + rce->bufferRate;
     if (m_param->csvLogLevel >= 2)
         m_unclippedBufferFillFinal = m_bufferFillFinal;
 
@@ -3105,18 +3089,18 @@ int RateControl::updateVbv(int64_t bits, RateControlEntry* rce)
             filler = (int)(m_bufferFillFinal - m_bufferSize);
             filler += FILLER_OVERHEAD * 8;
         }
-        m_bufferFillFinal -= filler;
+        m_bufferFillFinal = double(m_bufferFillFinal) - filler;
         bufferBits = X265_MIN(bits + filler + m_bufferExcess, rce->bufferRate);
         m_bufferExcess = X265_MAX(m_bufferExcess - bufferBits + bits + filler, 0);
-        m_bufferFillActual += bufferBits - bits - filler;
+        m_bufferFillActual = double(m_bufferFillActual) + bufferBits - bits - filler;
     }
     else
     {
-        m_bufferFillFinal = X265_MIN(m_bufferFillFinal, m_bufferSize);
+        m_bufferFillFinal = X265_MIN(double(m_bufferFillFinal), m_bufferSize);
         bufferBits = X265_MIN(bits + m_bufferExcess, rce->bufferRate);
         m_bufferExcess = X265_MAX(m_bufferExcess - bufferBits + bits, 0);
-        m_bufferFillActual += bufferBits - bits;
-        m_bufferFillActual = X265_MIN(m_bufferFillActual, m_bufferSize);
+        m_bufferFillActual = double(m_bufferFillActual) + bufferBits - bits;
+        m_bufferFillActual = X265_MIN(double(m_bufferFillActual), m_bufferSize);
     }
     return filler;
 }
@@ -3137,7 +3121,7 @@ int RateControl::rateControlEnd(Frame* curFrame, int64_t bits, RateControlEntry*
         orderValue = m_startEndOrder.waitForChange(orderValue);
     }
 
-    ScopedLock lock(m_rateControlLock);
+    ScopedSpinLock lock(m_rateControlLock);
     FrameData& curEncData = *curFrame->m_encData;
     int64_t actualBits = bits;
     Slice *slice = curEncData.m_slice;
@@ -3241,7 +3225,7 @@ int RateControl::rateControlEnd(Frame* curFrame, int64_t bits, RateControlEntry*
                 * Not perfectly accurate with B-refs, but good enough. */
             m_cplxrSum += (bits * x265_qp2qScale(rce->qpaRc) / (rce->qRceq * fabs(m_param->rc.pbFactor))) - (rce->rowCplxrSum);
         }
-        m_wantedBitsWindow += m_frameDuration * (m_bRcReConfig ? (curFrame->m_targetBitrate * 1000) : m_bitrate);
+        m_wantedBitsWindow = double(m_wantedBitsWindow) + m_frameDuration * (m_bRcReConfig ? (curFrame->m_targetBitrate * 1000) : m_bitrate);
         m_totalBits.add(bits - rce->rowTotalBits);
         m_encodedBits += actualBits;
         m_encodedSegmentBits += actualBits;

--- a/source/encoder/ratecontrol.cpp
+++ b/source/encoder/ratecontrol.cpp
@@ -202,7 +202,7 @@ RateControl::RateControl(x265_param& p, Encoder *top)
     m_fps = (double)m_param->fpsNum / m_param->fpsDenom;
     m_startEndOrder.set(0);
     m_bTerminated = false;
-    m_finalFrameCount = 0;
+    m_finalFrameCount.set(0);
     m_numEntries = 0;
     m_isSceneTransition = false;
     m_lastPredictorReset = 0;
@@ -2467,7 +2467,7 @@ void RateControl::rateControlUpdateStats(RateControlEntry* rce)
         rce->rowCplxrSum = rce->rowTotalBits * x265_qp2qScale(rce->qpaRc) / (rce->qRceq * fabs(m_param->rc.pbFactor));
 
     m_cplxrSum += rce->rowCplxrSum;
-    m_totalBits += rce->rowTotalBits;
+    m_totalBits.add(rce->rowTotalBits);
 
     /* do not allow the next frame to enter rateControlStart() until this
      * frame has updated its mid-frame statistics */
@@ -2820,7 +2820,10 @@ double RateControl::predictRowsSizeSum(Frame* curFrame, RateControlEntry* rce, d
                 }
 
                 refRowSatdCost >>= X265_DEPTH - 8;
-                refQScale = refEncData.m_rowStat[row].rowQpScale;
+                {
+                    ScopedLock lock(refEncData.m_rowStatLock);
+                    refQScale = refEncData.m_rowStat[row].rowQpScale;
+                }
             }
 
             if (picType == I_SLICE || qScale >= refQScale)
@@ -2917,10 +2920,17 @@ int RateControl::rowVbvRateControl(Frame* curFrame, uint32_t row, RateControlEnt
         if (!m_isCbr)
             qpMin = X265_MAX(qpMin, rce->qpNoVbv);
 
-        double totalBitsNeeded = m_wantedBitsWindow;
+        double wantedBits;
+        double totalBits;
+        {
+            ScopedLock lock(m_rateControlLock);
+            wantedBits = m_wantedBitsWindow;
+            totalBits = (double)(int64_t)m_totalBits;
+        }
+        double totalBitsNeeded = wantedBits;
         if (m_param->totalFrames)
             totalBitsNeeded = (m_param->totalFrames * m_bitrate) / m_fps;
-        double abrOvershoot = (accFrameBits + m_totalBits - m_wantedBitsWindow) / totalBitsNeeded;
+        double abrOvershoot = (accFrameBits + totalBits - wantedBits) / totalBitsNeeded;
 
         while (qpVbv < qpMax
                && (((accFrameBits > rce->frameSizePlanned + rcTol) ||
@@ -2931,11 +2941,16 @@ int RateControl::rowVbvRateControl(Frame* curFrame, uint32_t row, RateControlEnt
         {
             qpVbv += stepSize;
             accFrameBits = predictRowsSizeSum(curFrame, rce, qpVbv, encodedBitsSoFar);
-            abrOvershoot = (accFrameBits + m_totalBits - m_wantedBitsWindow) / totalBitsNeeded;
+            abrOvershoot = (accFrameBits + totalBits - wantedBits) / totalBitsNeeded;
         }
 
+        double row0Qp;
+        {
+            ScopedLock lock(curEncData.m_rowStatLock);
+            row0Qp = curEncData.m_rowStat[0].rowQp;
+        }
         while (qpVbv > qpMin
-               && (qpVbv > curEncData.m_rowStat[0].rowQp || m_singleFrameVbv)
+               && (qpVbv > row0Qp || m_singleFrameVbv)
                && (((accFrameBits < rce->frameSizePlanned * 0.8f && qpVbv <= prevRowQp)
                    || accFrameBits < (rce->bufferFill - m_bufferSize + m_bufferRate) * 1.1
                    || (rce->vbvEndAdj && ((rce->bufferFill - accFrameBits) > (rce->targetFill * vbvEndBias))))
@@ -2943,7 +2958,7 @@ int RateControl::rowVbvRateControl(Frame* curFrame, uint32_t row, RateControlEnt
         {
             qpVbv -= stepSize;
             accFrameBits = predictRowsSizeSum(curFrame, rce, qpVbv, encodedBitsSoFar);
-            abrOvershoot = (accFrameBits + m_totalBits - m_wantedBitsWindow) / totalBitsNeeded;
+            abrOvershoot = (accFrameBits + totalBits - wantedBits) / totalBitsNeeded;
         }
 
         if (m_param->rc.bStrictCbr && m_param->totalFrames)
@@ -2954,7 +2969,7 @@ int RateControl::rowVbvRateControl(Frame* curFrame, uint32_t row, RateControlEnt
             {
                 qpVbv += stepSize;
                 accFrameBits = predictRowsSizeSum(curFrame, rce, qpVbv, encodedBitsSoFar);
-                abrOvershoot = (accFrameBits + m_totalBits - m_wantedBitsWindow) / totalBitsNeeded;
+                abrOvershoot = (accFrameBits + totalBits - wantedBits) / totalBitsNeeded;
             }
             if (qpVbv > curEncData.m_rowStat[0].rowQp &&
                 abrOvershoot < -0.1 && timeDone > 0.5 && accFrameBits < rce->frameSizePlanned - rcTol)
@@ -2973,8 +2988,10 @@ int RateControl::rowVbvRateControl(Frame* curFrame, uint32_t row, RateControlEnt
             accFrameBits = predictRowsSizeSum(curFrame, rce, qpVbv, encodedBitsSoFar);
         }
 
-        rce->frameSizeEstimated = accFrameBits;
-
+        {
+            ScopedLock lock(rce->m_rateControlEntryLock);
+            rce->frameSizeEstimated = accFrameBits;
+        }
         /* If the current row was large enough to cause a large QP jump, try re-encoding it. */
         if (qpVbv > qpMax && prevRowQp < qpMax && canReencodeRow)
         {
@@ -2995,7 +3012,10 @@ int RateControl::rowVbvRateControl(Frame* curFrame, uint32_t row, RateControlEnt
     else
     {
         int32_t encodedBitsSoFar = 0;
-        rce->frameSizeEstimated = predictRowsSizeSum(curFrame, rce, qpVbv, encodedBitsSoFar);
+        {
+            ScopedLock lock(rce->m_rateControlEntryLock);
+            rce->frameSizeEstimated = predictRowsSizeSum(curFrame, rce, qpVbv, encodedBitsSoFar);
+        }
 
         /* Last-ditch attempt: if the last row of the frame underflowed the VBV,
          * try again. */
@@ -3111,11 +3131,13 @@ int RateControl::rateControlEnd(Frame* curFrame, int64_t bits, RateControlEntry*
         /* no more frames are being encoded, so fake the start event if we would
          * have blocked on it. Note that this does not enforce rateControlEnd()
          * ordering during flush, but this has no impact on the outputs */
-        if (m_finalFrameCount && orderValue >= 2 * m_finalFrameCount)
+        int finalFrameCount = m_finalFrameCount.get();
+        if (finalFrameCount && orderValue >= 2 * finalFrameCount)
             break;
         orderValue = m_startEndOrder.waitForChange(orderValue);
     }
 
+    ScopedLock lock(m_rateControlLock);
     FrameData& curEncData = *curFrame->m_encData;
     int64_t actualBits = bits;
     Slice *slice = curEncData.m_slice;
@@ -3220,7 +3242,7 @@ int RateControl::rateControlEnd(Frame* curFrame, int64_t bits, RateControlEntry*
             m_cplxrSum += (bits * x265_qp2qScale(rce->qpaRc) / (rce->qRceq * fabs(m_param->rc.pbFactor))) - (rce->rowCplxrSum);
         }
         m_wantedBitsWindow += m_frameDuration * (m_bRcReConfig ? (curFrame->m_targetBitrate * 1000) : m_bitrate);
-        m_totalBits += bits - rce->rowTotalBits;
+        m_totalBits.add(bits - rce->rowTotalBits);
         m_encodedBits += actualBits;
         m_encodedSegmentBits += actualBits;
         m_segDur += m_frameDuration;
@@ -3241,7 +3263,7 @@ int RateControl::rateControlEnd(Frame* curFrame, int64_t bits, RateControlEntry*
     if (m_2pass)
     {
         m_expectedBitsSum += qScale2bits(rce, x265_qp2qScale(rce->newQp));
-        m_totalBits += bits - rce->rowTotalBits;
+        m_totalBits.add(bits - rce->rowTotalBits);
     }
 
     if (m_isVbv)
@@ -3390,7 +3412,7 @@ int RateControl::writeRateControlFrameStats(Frame* curFrame, RateControlEntry* r
  * unambiguously known */
 void RateControl::setFinalFrameCount(int count)
 {
-    m_finalFrameCount = count;
+    m_finalFrameCount.set(count);
     /* unblock waiting threads */
     m_startEndOrder.poke();
 }

--- a/source/encoder/ratecontrol.h
+++ b/source/encoder/ratecontrol.h
@@ -121,6 +121,7 @@ struct RateControlEntry
     int      rpsIdx;
     RPS      rpsData;
     bool     isFadeEnd;
+    Lock m_rateControlEntryLock;
 };
 
 class RateControl
@@ -191,7 +192,7 @@ public:
     double  m_shortTermCplxCount;
     double  m_lastRceq;
     double  m_qCompress;
-    int64_t m_totalBits;        /* total bits used for already encoded frames (after ammortization) */
+    AtomicInt64 m_totalBits;        /* total bits used for already encoded frames (after ammortization) */
     int64_t m_encodedBits;      /* bits used for encoded frames (without ammortization) */
     int64_t m_encodedSegmentBits;      /* bits used for encoded frames in a segment*/
     double  m_movingSumComplexitySeg[3];
@@ -225,8 +226,9 @@ public:
      * rceUpdate 12
      * rceEnd    11 */
     ThreadSafeInteger m_startEndOrder;
-    int     m_finalFrameCount;   /* set when encoder begins flushing */
+    ThreadSafeInteger m_finalFrameCount;   /* set when encoder begins flushing */
     bool    m_bTerminated;       /* set true when encoder is closing */
+    Lock m_rateControlLock;
 
     /* hrd stuff */
     SEIBufferingPeriod m_bufPeriodSEI;

--- a/source/encoder/ratecontrol.h
+++ b/source/encoder/ratecontrol.h
@@ -29,6 +29,7 @@
 #include "common.h"
 #include "sei.h"
 #include "ringmem.h"
+#include "threading.h"
 
 namespace X265_NS {
 // encoder namespace
@@ -90,7 +91,7 @@ struct RateControlEntry
     bool    vbvEndAdj;
     double  frameDuration;
     double  clippedDuration;
-    double  frameSizeEstimated; /* hold frameSize, updated from cu level vbv rc */
+    AtomicDouble frameSizeEstimated; /* hold frameSize, updated from cu level vbv rc */
     double  frameSizeMaximum;   /* max frame Size according to minCR restrictions and level of the video */
     int     sliceType;
     int     bframes;
@@ -121,7 +122,7 @@ struct RateControlEntry
     int      rpsIdx;
     RPS      rpsData;
     bool     isFadeEnd;
-    Lock m_rateControlEntryLock;
+    SpinLock m_rateControlEntryLock;
 };
 
 class RateControl
@@ -156,7 +157,7 @@ public:
     double m_bitrate;
     double m_rateFactorConstant;
     double m_bufferSize;
-    double m_bufferFillFinal;  /* real buffer as of the last finished frame */
+    AtomicDouble m_bufferFillFinal;  /* real buffer as of the last finished frame */
     double m_unclippedBufferFillFinal; /* real unclipped buffer as of the last finished frame used to log in CSV*/
     double m_bufferFill;       /* planned buffer, if all in-progress frames hit their bit budget */
     double m_bufferRate;       /* # of bits added to buffer_fill after each frame */
@@ -164,7 +165,7 @@ public:
     double m_rateFactorMaxIncrement; /* Don't allow RF above (CRF + this value). */
     double m_rateFactorMaxDecrement; /* don't allow RF below (this value). */
     double m_avgPFrameQp;
-    double m_bufferFillActual;
+    AtomicDouble m_bufferFillActual;
     double m_bufferExcess;
     double m_minBufferFill;
     double m_maxBufferFill;
@@ -181,7 +182,7 @@ public:
     int     m_framesDone;        /* # of frames passed through RateCotrol already */
     int64_t m_iBits;
     double  m_cplxrSum;          /* sum of bits*qscale/rceq */
-    double  m_wantedBitsWindow;  /* target bitrate * window */
+    AtomicDouble m_wantedBitsWindow;  /* target bitrate * window */
     double  m_accumPQp;          /* for determining I-frame quant */
     double  m_accumPNorm;
     double  m_lastQScaleFor[3];  /* last qscale for a specific pict type, used for max_diff & ipb factor stuff */
@@ -228,7 +229,7 @@ public:
     ThreadSafeInteger m_startEndOrder;
     ThreadSafeInteger m_finalFrameCount;   /* set when encoder begins flushing */
     bool    m_bTerminated;       /* set true when encoder is closing */
-    Lock m_rateControlLock;
+    SpinLock m_rateControlLock;
 
     /* hrd stuff */
     SEIBufferingPeriod m_bufPeriodSEI;

--- a/source/encoder/slicetype.cpp
+++ b/source/encoder/slicetype.cpp
@@ -1274,7 +1274,10 @@ void Lookahead::findJob(int /*workerThreadID*/)
     if (m_inputQueue.size() >= m_fullQueueSize && !m_sliceTypeBusy && m_isActive)
         doDecide = m_sliceTypeBusy = true;
     else
-        doDecide = m_helpWanted = false;
+    {
+        m_helpWanted = false;
+        doDecide = false;
+    }
     m_inputLock.release();
 
     if (!doDecide)

--- a/source/encoder/slicetype.cpp
+++ b/source/encoder/slicetype.cpp
@@ -1254,7 +1254,9 @@ void Lookahead::checkLookaheadQueue(int &frameCnt)
 void Lookahead::flush()
 {
     /* force slicetypeDecide to run until the input queue is empty */
+    m_inputLock.acquire();
     m_fullQueueSize = 1;
+    m_inputLock.release();
     m_filled = true;
 }
 
@@ -1323,7 +1325,9 @@ Frame* Lookahead::getDecidedPicture()
         if (wait)
             m_outputSignal.wait();
 
+        m_outputLock.acquire();
         out = m_outputQueue.popFront();
+        m_outputLock.release();
         if (out)
             m_inputCount--;
         return out;
@@ -2175,6 +2179,7 @@ void Lookahead::slicetypeDecide()
         /* pre-calculate all motion searches, using many worker threads */
         CostEstimateGroup estGroup(*this, frames);
         Frame* frameEnc = m_inputQueue.first();
+        m_inputLock.acquire();
         for (int b = 0; b < m_inputQueue.size(); b++)
         {
             if (m_param->bEnableTemporalFilter && isFilterThisframe(frameEnc->m_mcstf->m_sliceTypeConfig, frameEnc->m_lowres.sliceType))
@@ -2199,6 +2204,7 @@ void Lookahead::slicetypeDecide()
             }
             frameEnc = frameEnc->m_next;
         }
+        m_inputLock.release();
 
         /* auto-disable after the first batch if pool is small */
         m_bBatchMotionSearch &= m_pool->m_numWorkers >= 4;
@@ -4098,8 +4104,9 @@ void CostEstimateGroup::processTasks(int workerThreadID)
             ProfileScopeEvent(estCostSingle);
 
             Estimate& e = m_estimates[i];
+            m_lookahead.m_inputLock.acquire();
             Frame* curFrame = m_lookahead.m_inputQueue.getPOC(e.b);
-
+            m_lookahead.m_inputLock.release();
             if (m_lookahead.m_param->bEnableTemporalFilter && curFrame && (curFrame->m_lowres.sliceType == X265_TYPE_IDR || curFrame->m_lowres.sliceType == X265_TYPE_I || curFrame->m_lowres.sliceType == X265_TYPE_P))
             {
                 estimatelowresmotion(m_metld, curFrame, e.p0);
@@ -4257,7 +4264,7 @@ void CostEstimateGroup::estimateCUCost(LookaheadTLD& tld, int cuX, int cuY, int 
     Lowres *fref1 = m_frames[p1];
     Lowres *fenc  = m_frames[b];
 
-    ReferencePlanes *wfref0 = fenc->weightedRef[b - p0].isWeighted && !hme ? &fenc->weightedRef[b - p0] : fref0;
+    ReferencePlanes *wfref0 = (bool)fenc->weightedRef[b - p0].isWeighted && !hme ? &fenc->weightedRef[b - p0] : fref0;
 
     const int widthInCU = hme ? m_lookahead.m_4x4Width : m_lookahead.m_8x8Width;
     const int heightInCU = hme ? m_lookahead.m_4x4Height : m_lookahead.m_8x8Height;

--- a/source/encoder/threadedme.cpp
+++ b/source/encoder/threadedme.cpp
@@ -164,12 +164,11 @@ void ThreadedME::findJob(int workerThreadId)
     m_taskQueueLock.acquire();
     if (m_taskQueue.empty())
     {
-        m_helpWanted = false;
         m_taskQueueLock.release();
+        m_helpWanted = true;
         return;
     }
-    
-    m_helpWanted = true;
+
     int64_t stime = x265_mdate();
 
 #ifdef DETAILED_CU_STATS
@@ -179,6 +178,7 @@ void ThreadedME::findJob(int workerThreadId)
 
     CTUTask task = m_taskQueue.top();
     m_taskQueue.pop();
+    m_helpWanted = !m_taskQueue.empty();
     m_taskQueueLock.release();
 
     int numCols = (m_param->sourceWidth + m_param->maxCUSize - 1) / m_param->maxCUSize;
@@ -218,8 +218,9 @@ void ThreadedME::findJob(int workerThreadId)
 
 void ThreadedME::stopJobs()
 {
-    this->m_active = false;
+    m_active = false;
     m_taskEvent.trigger();
+    stop();
 }
 
 void ThreadedME::destroy()

--- a/source/encoder/threadedme.h
+++ b/source/encoder/threadedme.h
@@ -167,7 +167,7 @@ public:
     Lock                    m_taskQueueLock;
     Event                   m_taskEvent;
 
-    volatile bool           m_active;
+    AtomicBool              m_active;       /* accessed lock-free across threads; use ATOMIC_LOAD/ATOMIC_STORE */
     unsigned long long      m_enqueueSeq;
 
     ThreadLocalData*        m_tld;

--- a/source/encoder/weightPrediction.cpp
+++ b/source/encoder/weightPrediction.cpp
@@ -325,22 +325,10 @@ void weightAnalyse(Slice& slice, Frame& frame, x265_param& param)
                 mvs = fenc.lowresMvs[list][diffPoc];
 
                 /* test whether this motion search was performed by lookahead */
-                if (mvs[0].x != 0x7FFF)
-                {
-                    /* reference chroma planes must be extended prior to being
-                     * used as motion compensation sources */
-                    if (!refFrame->m_bChromaExtended && param.internalCsp != X265_CSP_I400 && frame.m_fencPic->m_picCsp != X265_CSP_I400)
-                    {
-                        refFrame->m_bChromaExtended = true;
-                        PicYuv *refPic = refFrame->m_fencPic;
-                        int width = refPic->m_picWidth >> cache.hshift;
-                        int height = refPic->m_picHeight >> cache.vshift;
-                        extendPicBorder(refPic->m_picOrg[1], refPic->m_strideC, width, height, refPic->m_chromaMarginX, refPic->m_chromaMarginY);
-                        extendPicBorder(refPic->m_picOrg[2], refPic->m_strideC, width, height, refPic->m_chromaMarginX, refPic->m_chromaMarginY);
-                    }
-                }
-                else
+                if (mvs[0].x == 0x7FFF)
                     mvs = 0;
+                /* chroma borders are extended unconditionally at frame-input
+                 * time in Encoder::encode(); no lazy extension needed here */
             }
 
             /* prepare inputs to weight analysis */

--- a/source/input/y4m.h
+++ b/source/input/y4m.h
@@ -57,7 +57,7 @@ protected:
 
     bool alphaAvailable;
 
-    bool threadActive;
+    AtomicBool threadActive;
 
     ThreadSafeInteger readCount;
 

--- a/source/input/yuv.h
+++ b/source/input/yuv.h
@@ -49,7 +49,7 @@ protected:
 
     bool alphaAvailable;
 
-    bool threadActive;
+    AtomicBool threadActive;
 
     ThreadSafeInteger readCount;
 

--- a/source/output/reconplay.h
+++ b/source/output/reconplay.h
@@ -50,12 +50,12 @@ protected:
 
     FILE*  outputPipe;     /* The output pipe for player */
     size_t frameSize;      /* size of one frame in pixels */
-    bool   threadActive;   /* worker thread is active */
+    AtomicBool   threadActive;   /* worker thread is active */
     int    width;          /* width of frame */
     int    height;         /* height of frame */
     int    colorSpace;     /* color space of frame */
 
-    int    poc[RECON_BUF_SIZE];
+    AtomicInt32    poc[RECON_BUF_SIZE];
     pixel* frameData[RECON_BUF_SIZE];
 
     /* Note that the class uses read and write counters to signal that reads and


### PR DESCRIPTION
- This PR fixes data races flagged by ThreadSanitizer (TSAN) across the encoder's multi-threaded code paths, including encoder shared state, TME, rate control row stats, and weight analysis. 
- It also includes code-quality fixes addressing issues reported by the PR CI pipeline.
- TSAN tested across all presets (8-bit and 10-bit) and across all CLIs in the x265 regression suite. Smoke, regression, performance, and quality tested.