### PR TITLE
AArch64: Use simpler sign expressions in Neon intrinsics code

### DIFF
--- a/source/common/aarch64/loopfilter-prim.cpp
+++ b/source/common/aarch64/loopfilter-prim.cpp
@@ -15,9 +15,10 @@ namespace
 
 static inline int8x8_t sign_diff_neon(const uint8x8_t in0, const uint8x8_t in1)
 {
-    int16x8_t in = vreinterpretq_s16_u16(vsubl_u8(in0, in1));
+    uint8x8_t lt = vclt_u8(in0, in1);
+    uint8x8_t gt = vcgt_u8(in0, in1);
 
-    return vmovn_s16(vmaxq_s16(vminq_s16(in, vdupq_n_s16(1)), vdupq_n_s16(-1)));
+    return vreinterpret_s8_u8(vsub_u8(lt, gt));
 }
 
 static void calSign_neon(int8_t *dst, const pixel *src1, const pixel *src2, const int endX)

--- a/source/common/aarch64/sao-prim.h
+++ b/source/common/aarch64/sao-prim.h
@@ -35,7 +35,7 @@ static inline int8x16_t signOf_neon(const pixel *a, const pixel *b)
     uint16x8_t s1_lo = vld1q_u16(b);
     uint16x8_t s1_hi = vld1q_u16(b + 8);
 
-    // signOf(a - b) = -(a > b ? -1 : 0) | (a < b ? -1 : 0)
+    // signOf(a - b) = (a < b ? -1 : 0) - (a > b ? -1 : 0)
     int16x8_t cmp0_lo = vreinterpretq_s16_u16(vcgtq_u16(s0_lo, s1_lo));
     int16x8_t cmp0_hi = vreinterpretq_s16_u16(vcgtq_u16(s0_hi, s1_hi));
     int16x8_t cmp1_lo = vreinterpretq_s16_u16(vcgtq_u16(s1_lo, s0_lo));
@@ -47,11 +47,11 @@ static inline int8x16_t signOf_neon(const pixel *a, const pixel *b)
     uint8x16_t s0 = vld1q_u8(a);
     uint8x16_t s1 = vld1q_u8(b);
 
-    // signOf(a - b) = -(a > b ? -1 : 0) | (a < b ? -1 : 0)
+    // signOf(a - b) = (a < b ? -1 : 0) - (a > b ? -1 : 0)
     int8x16_t cmp0 = vreinterpretq_s8_u8(vcgtq_u8(s0, s1));
     int8x16_t cmp1 = vreinterpretq_s8_u8(vcgtq_u8(s1, s0));
 #endif // HIGH_BIT_DEPTH
-    return vorrq_s8(vnegq_s8(cmp0), cmp1);
+    return vsubq_s8(cmp1, cmp0);
 }
 
 namespace X265_NS {


### PR DESCRIPTION
In `sign_diff_neon`, using the expression `(a < b) - (a > 0)` avoids the need for a widening subtraction and subsequent narrowing while producing an identical result. Benchmarking with LLVM 22 on a Neoverse V2 machine, this improves performance on the `calSign`/`saoCuOrg*` functions by 6-7%.

In `signOf_neon` this has no performance difference since LLVM 22 already performs the `(-a) | b ==> a - b` optimisation itself, so just update the intrinsics to reflect the simpler assembly sequence and to match the previous `sign_diff_neon` change.