### PR TITLE
common: silence Clang -Wnontrivial-memcall warnings

### DIFF
--- a/source/common/slice.h
+++ b/source/common/slice.h
@@ -295,7 +295,7 @@ struct SPS
 
     SPS()
     {
-        memset(this, 0, sizeof(*this));
+        memset(static_cast<void*>(this), 0, sizeof(*this));
     }
 
     ~SPS()

--- a/source/common/threadpool.cpp
+++ b/source/common/threadpool.cpp
@@ -657,7 +657,7 @@ ThreadPool* ThreadPool::allocThreadPools(x265_param* p, int& numPools, bool isTh
 
 ThreadPool::ThreadPool()
 {
-    memset(this, 0, sizeof(*this));
+    memset(static_cast<void*>(this), 0, sizeof(*this));
 }
 
 bool ThreadPool::create(int numThreads, int maxProviders, uint64_t nodeMask)


### PR DESCRIPTION
### Summary

Suppress Clang's `-Wnontrivial-memcall` warning by explicitly casting `this`
to `void*` before calling `memset()`.

This makes the intent explicit and silences the warning without changing
runtime behavior.

### Testing

- Built x265 with Clang.
- Verified that the warning is no longer emitted.