### PR TITLE
ci: check out PR head in build jobs, fix concurrency and cache scoping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,14 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
-# Cancel superseded runs on PRs/branches; let all main branch runs complete
+# Grouping: PRs by PR number, so different PRs never block or cancel each other
+# (a new commit on a PR still supersedes that PR's own in-flight run). Pushes to
+# the default branch get one group PER COMMIT, so every commit is built in
+# parallel and none is dropped while queued. Other branches group by ref, so WIP
+# pushes supersede each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref_name == github.event.repository.default_branch && github.sha || github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'push' && github.ref_name != github.event.repository.default_branch) }}
 
 # Least-privilege: jobs only need to read the repo
 permissions:
@@ -390,13 +394,19 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Cache ccache
         uses: actions/cache@v5
         with:
           path: ~/.ccache
-          key: ccache-8bit-${{ runner.os }}-${{ github.sha }}
-          restore-keys: ccache-8bit-${{ runner.os }}-
+          key: ccache-8bit-${{ runner.os }}-${{ github.event.pull_request.number && 'pr' || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
+          restore-keys: |
+            ${{ github.event.pull_request.number && format('ccache-8bit-{0}-pr-', runner.os) || '' }}
+            ccache-8bit-${{ runner.os }}-master-
 
       - name: Cache apt packages
         uses: actions/cache@v5
@@ -458,13 +468,19 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Cache ccache
         uses: actions/cache@v5
         with:
           path: ~/.ccache
-          key: ccache-10bit-${{ runner.os }}-${{ github.sha }}
-          restore-keys: ccache-10bit-${{ runner.os }}-
+          key: ccache-10bit-${{ runner.os }}-${{ github.event.pull_request.number && 'pr' || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
+          restore-keys: |
+            ${{ github.event.pull_request.number && format('ccache-10bit-{0}-pr-', runner.os) || '' }}
+            ccache-10bit-${{ runner.os }}-master-
 
       - name: Cache apt packages
         uses: actions/cache@v5
@@ -517,13 +533,19 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Cache ccache
         uses: actions/cache@v5
         with:
           path: ~/.ccache
-          key: ccache-12bit-${{ runner.os }}-${{ github.sha }}
-          restore-keys: ccache-12bit-${{ runner.os }}-
+          key: ccache-12bit-${{ runner.os }}-${{ github.event.pull_request.number && 'pr' || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
+          restore-keys: |
+            ${{ github.event.pull_request.number && format('ccache-12bit-{0}-pr-', runner.os) || '' }}
+            ccache-12bit-${{ runner.os }}-master-
 
       - name: Cache apt packages
         uses: actions/cache@v5
@@ -578,13 +600,19 @@ jobs:
     needs: [build-8bit, build-10bit, build-12bit]
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Cache ccache
         uses: actions/cache@v5
         with:
           path: ~/.ccache
-          key: ccache-multilib-${{ runner.os }}-${{ github.sha }}
-          restore-keys: ccache-multilib-${{ runner.os }}-
+          key: ccache-multilib-${{ runner.os }}-${{ github.event.pull_request.number && 'pr' || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
+          restore-keys: |
+            ${{ github.event.pull_request.number && format('ccache-multilib-{0}-pr-', runner.os) || '' }}
+            ccache-multilib-${{ runner.os }}-master-
 
       - name: Cache apt packages
         uses: actions/cache@v5


### PR DESCRIPTION
## Changes
- **Build jobs now check out the PR's commit.** The four build jobs used a bare
  `actions/checkout@v6`, which resolved to master - so every PR built and tested
  master instead of the proposed change. Test jobs consume those binaries, so the
  whole suite was validating the wrong code. Now they use
  `ref: ${{ github.event.pull_request.head.sha || github.sha }}`, matching what
  `code-quality` already did.

- **Different PRs no longer cancel each other.** Concurrency grouped by
  `github.ref`, which for a PR is the base branch, so every PR shared one group
  with cancelling enabled. Runs are now grouped by PR number: PRs run in parallel,
  and a new commit supersedes only its own PR's run.

- **Every master commit gets its own run.** Master pushes previously queued one at
  a time, and rapid merges dropped the middle commits while they sat pending.
  Master pushes now group by commit SHA, so each commit is built independently and
  none is skipped.

- **Fork PRs can no longer poison master's build cache.** Cache scope follows the
  base branch under `pull_request_target`, so a fork PR's build could write ccache
  entries that later master builds restored. Caches are now split into `pr-` and
  `master-` namespaces; master reads only its own.

## Note

The first run after this merges will build cold, since the old cache
names no longer match.