### PR TITLE
Add fovea/selective-mcstf regression tests and group thread pool creation logs

### DIFF
--- a/source/common/param.cpp
+++ b/source/common/param.cpp
@@ -2137,6 +2137,8 @@ void x265_print_params(x265_param* param)
     if (param->logLevel < X265_LOG_INFO)
         return;
 
+    x265_log(param, X265_LOG_INFO, "Slices                              : %d\n", param->maxSlices);
+
     if (param->interlaceMode)
         x265_log(param, X265_LOG_INFO, "Interlaced field inputs             : %s\n", x265_interlace_names[param->interlaceMode]);
 

--- a/source/encoder/encoder.cpp
+++ b/source/encoder/encoder.cpp
@@ -302,23 +302,6 @@ void Encoder::create()
         p->bThreadedME = 0;
     }
 
-    x265_log(p, X265_LOG_INFO, "Slices                              : %d\n", p->maxSlices);
-
-    char buf[128];
-    int len = 0;
-    if (p->bEnableWavefront)
-        len += snprintf(buf + len, sizeof(buf) - len, "wpp(%d rows)", rows);
-    if (p->bDistributeModeAnalysis)
-        len += snprintf(buf + len,  sizeof(buf) - len, "%spmode", len ? " + " : "");
-    if (p->bDistributeMotionEstimation)
-        len += snprintf(buf + len, sizeof(buf) - len, "%spme", len ? " + " : "");
-    if (p->bThreadedME)
-        len += snprintf(buf + len, sizeof(buf) - len, "%sthreaded-me(%d workers)", len ? " + ": "", p->tmeNumThreads);
-    if (!len)
-        strcpy(buf, "none");
-
-    x265_log(p, X265_LOG_INFO, "frame threads / pool features       : %d / %s\n", p->frameNumThreads, buf);
-
     for (int i = 0; i < m_param->frameNumThreads; i++)
     {
         m_frameEncoder[i] = new FrameEncoder;
@@ -378,13 +361,6 @@ void Encoder::create()
     else if (m_scalingList.parseScalingList(m_param->scalingLists))
         m_aborted = true;
 
-    /* Register the Lookahead job provider only after the FrameEncoders have
-     * claimed their job-provider ids. When lookahead shares a physical pool
-     * with frame encoders (the default --lookahead-threads 0 case), a
-     * FrameEncoder must own jpId 0 on that pool: the jpId-0 provider is the one
-     * that allocates and distributes the pool's ThreadLocalData, and it must be
-     * a FrameEncoder. Registering lookahead first would give it jpId 0, leaving
-     * every FrameEncoder on that pool with a NULL m_tld and crashing at encode. */
     int lookaheadPools = m_numPools;
     ThreadPool* lookAheadThreadPool = 0;
     if (m_param->lookaheadThreads > 0)
@@ -404,6 +380,21 @@ void Encoder::create()
     if (m_param->lookaheadThreads > 0)
         for (int i = 0; i < lookaheadPools; i++)
             lookAheadThreadPool[i].start();
+
+    char buf[128];
+    int len = 0;
+    if (p->bEnableWavefront)
+        len += snprintf(buf + len, sizeof(buf) - len, "wpp(%d rows)", rows);
+    if (p->bDistributeModeAnalysis)
+        len += snprintf(buf + len,  sizeof(buf) - len, "%spmode", len ? " + " : "");
+    if (p->bDistributeMotionEstimation)
+        len += snprintf(buf + len, sizeof(buf) - len, "%spme", len ? " + " : "");
+    if (p->bThreadedME)
+        len += snprintf(buf + len, sizeof(buf) - len, "%sthreaded-me(%d workers)", len ? " + ": "", p->tmeNumThreads);
+    if (!len)
+        strcpy(buf, "none");
+
+    x265_log(p, X265_LOG_INFO, "frame threads / pool features       : %d / %s\n", p->frameNumThreads, buf);
 
     m_dpb = new DPB(m_param);
 

--- a/source/test/regression-tests.txt
+++ b/source/test/regression-tests.txt
@@ -208,3 +208,10 @@ CrowdRun_1920x1080_50_10bit_422.yuv,--preset medium --threaded-me --no-wpp --no-
 DucksAndLegs_1920x1080_60_10bit_444.yuv,--preset slow --threaded-me --temporal-layers 2 --no-psy-rd --qg-size 32
 old_town_cross_444_720p50.y4m,--preset faster --threaded-me --me sea --weightp --limit-modes
 big_buck_bunny_360p24.y4m,--preset medium --threaded-me --no-wpp --aq-mode 3 --aq-strength 1.5 --weightb
+
+#Selective MCSTF test
+crowd_run_1080p50.y4m, --bitrate 5000 --selective-mcstf --preset veryslow
+
+#Fovea tests
+nature_1920x1080_25.yuv,--crf 28 --fovea-gaze 960,540 --fovea-delta 20
+nature_1920x1080_25.yuv,--qp 28 --fovea-delta 20 --fovea-gaze-file gaze_nature.txt


### PR DESCRIPTION
## Adds new command lines to the regression test list to cover

- --selective-mcstf: a new test using crowd_run_1080p50.y4m with --bitrate
  and --preset veryslow.
- --fovea-gaze / --fovea-delta: a new test on nature_1920x1080_25.yuv using
  static gaze coordinates.
- --fovea-gaze-file / --fovea-delta: a new test on the same sequence using
  an external gaze file (gaze_nature.txt).
