### PR TITLE
Fix garbage DTS values on short encode sessions

### DIFF
--- a/source/encoder/encoder.cpp
+++ b/source/encoder/encoder.cpp
@@ -128,6 +128,9 @@ Encoder::Encoder()
     m_reconfigureRc = false;
     m_encodedFrameNum = 0;
     m_pocLast = -1;
+    m_firstPts = 0;
+    m_bframeDelayTime = 0;
+    m_prevReorderedPts[0] = m_prevReorderedPts[1] = 0;
     m_curEncoder = 0;
     m_numLumaWPFrames = 0;
     m_numChromaWPFrames = 0;


### PR DESCRIPTION
- Encoder::Encoder() never initializes m_firstPts, m_bframeDelayTime, or m_prevReorderedPts[].
- If a stream is flushed before enough frames arrive to set m_bframeDelayTime legitimately, it retains whatever garbage was left on the heap (often leaked from a prior encoder session in long-running processes like ffmpeg), producing nonsensical DTS values.
- Fix: initialize all three fields to 0 in the constructor, so the fallback DTS calculation (reorderedPts - 0) is correct when no real B-frame reordering has occurred yet.
- Fixes #781 