### PR TITLE
Expand x265 CI to macOS/AArch64/Windows with parallel multilib builds and binary-reuse smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,14 +388,35 @@ jobs:
         if: steps.changed.outputs.has_changes == 'false'
         run: echo "[INFO] No files changed. Quality checks not applicable."
 
-  build-8bit:
-    name: "Build 8-bit"
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Phase 1 (cont'd) – Builds (parallel matrix per bit-depth + multilib, per platform)
+  # Linux, macOS, AArch64 (cross-compiled) and Windows each build 8-bit, 10-bit,
+  # 12-bit and multilib variants in parallel.
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  build-linux:
+    name: "Build Linux (${{ matrix.variant }}, ${{ matrix.config }})"
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [8bit, 10bit, 12bit]
+        config: [Release, Debug]
+        # Multilib components — Release, run as extra parallel legs of this
+        # same matrix. The final "linked" 8-bit binary is built by a separate
+        # build-linux-multilib job that downloads these two component libs.
+        include:
+          - variant: multilib-12bit-component
+            config: Release
+          - variant: multilib-10bit-component
+            config: Release
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
           allow-unsafe-pr-checkout: true
 
@@ -403,17 +424,17 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.ccache
-          key: ccache-8bit-${{ runner.os }}-${{ github.event.pull_request.number && 'pr' || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
+          key: ccache-linux-${{ matrix.variant }}-${{ matrix.config }}-${{ github.event.pull_request.number && format('pr{0}', github.event.pull_request.number) || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
           restore-keys: |
-            ${{ github.event.pull_request.number && format('ccache-8bit-{0}-pr-', runner.os) || '' }}
-            ccache-8bit-${{ runner.os }}-master-
+            ${{ github.event.pull_request.number && format('ccache-linux-{0}-{1}-pr{2}-', matrix.variant, matrix.config, github.event.pull_request.number) || '' }}
+            ccache-linux-${{ matrix.variant }}-${{ matrix.config }}-master-
 
       - name: Cache apt packages
         uses: actions/cache@v5
         with:
           path: /home/runner/apt-archives
-          key: apt-build-${{ runner.os }}-v2
-          restore-keys: apt-build-${{ runner.os }}-v2
+          key: apt-build-linux-v2
+          restore-keys: apt-build-linux-v2
       - name: Pre-populate apt cache
         run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
 
@@ -428,12 +449,14 @@ jobs:
           mkdir -p /home/runner/apt-archives
           cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
 
-      - name: Build
+      # ── 8-bit ──────────────────────────────────────────────────────────────
+      - name: Build 8-bit
+        if: matrix.variant == '8bit'
         run: |
           export PATH="/usr/lib/ccache:$PATH"
           mkdir -p build/8bit && cd build/8bit
           cmake ../../source \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
             -DENABLE_SHARED=OFF \
             -DENABLE_CLI=ON \
             -DENABLE_ASSEMBLY=ON \
@@ -441,73 +464,20 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           make -j$(nproc)
-          test -f x265      && echo "CLI binary OK"
-          test -f libx265.a && echo "Static library OK"
+          test -f x265      && echo "8-bit CLI OK (${{ matrix.config }})"
+          test -f libx265.a && echo "8-bit static lib OK"
           ./x265 --version
           echo "--- Unit tests ---"
           ./test/TestBench
 
-      - name: Upload CLI binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: x265-8bit
-          path: build/8bit/x265
-          retention-days: 3
-
-      - name: Upload library artifacts
-        if: github.event_name != 'pull_request_target'
-        uses: actions/upload-artifact@v7
-        with:
-          name: lib-8bit
-          path: build/8bit/libx265.a
-          retention-days: 3
-
-  build-10bit:
-    name: "Build 10-bit"
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          persist-credentials: false
-          allow-unsafe-pr-checkout: true
-
-      - name: Cache ccache
-        uses: actions/cache@v5
-        with:
-          path: ~/.ccache
-          key: ccache-10bit-${{ runner.os }}-${{ github.event.pull_request.number && 'pr' || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
-          restore-keys: |
-            ${{ github.event.pull_request.number && format('ccache-10bit-{0}-pr-', runner.os) || '' }}
-            ccache-10bit-${{ runner.os }}-master-
-
-      - name: Cache apt packages
-        uses: actions/cache@v5
-        with:
-          path: /home/runner/apt-archives
-          key: apt-build-${{ runner.os }}-v2
-          restore-keys: apt-build-${{ runner.os }}-v2
-      - name: Pre-populate apt cache
-        run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq build-essential cmake nasm ccache libnuma-dev
-
-      - name: Prepare apt cache
-        if: always()
-        run: |
-          mkdir -p /home/runner/apt-archives
-          cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
-
-      - name: Build
+      # ── 10-bit ─────────────────────────────────────────────────────────────
+      - name: Build 10-bit
+        if: matrix.variant == '10bit'
         run: |
           export PATH="/usr/lib/ccache:$PATH"
           mkdir -p build/10bit && cd build/10bit
           cmake ../../source \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
             -DHIGH_BIT_DEPTH=ON \
             -DENABLE_SHARED=OFF \
             -DENABLE_CLI=ON \
@@ -516,63 +486,18 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           make -j$(nproc)
-          test -f x265 && echo "10-bit CLI OK"
+          test -f x265 && echo "10-bit CLI OK (${{ matrix.config }})"
           ./x265 --version
           ./test/TestBench
 
-      - name: Upload CLI binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: x265-10bit
-          path: build/10bit/x265
-          retention-days: 3
-
-  build-12bit:
-    name: "Build 12-bit"
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          persist-credentials: false
-          allow-unsafe-pr-checkout: true
-
-      - name: Cache ccache
-        uses: actions/cache@v5
-        with:
-          path: ~/.ccache
-          key: ccache-12bit-${{ runner.os }}-${{ github.event.pull_request.number && 'pr' || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
-          restore-keys: |
-            ${{ github.event.pull_request.number && format('ccache-12bit-{0}-pr-', runner.os) || '' }}
-            ccache-12bit-${{ runner.os }}-master-
-
-      - name: Cache apt packages
-        uses: actions/cache@v5
-        with:
-          path: /home/runner/apt-archives
-          key: apt-build-${{ runner.os }}-v2
-          restore-keys: apt-build-${{ runner.os }}-v2
-      - name: Pre-populate apt cache
-        run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq build-essential cmake nasm ccache libnuma-dev
-
-      - name: Prepare apt cache
-        if: always()
-        run: |
-          mkdir -p /home/runner/apt-archives
-          cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
-
-      - name: Build
+      # ── 12-bit ─────────────────────────────────────────────────────────────
+      - name: Build 12-bit
+        if: matrix.variant == '12bit'
         run: |
           export PATH="/usr/lib/ccache:$PATH"
           mkdir -p build/12bit && cd build/12bit
           cmake ../../source \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
             -DHIGH_BIT_DEPTH=ON \
             -DMAIN12=ON \
             -DENABLE_SHARED=OFF \
@@ -582,59 +507,13 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           make -j$(nproc)
-          test -f x265 && echo "12-bit CLI OK"
+          test -f x265 && echo "12-bit CLI OK (${{ matrix.config }})"
           ./x265 --version
           ./test/TestBench
 
-      - name: Upload CLI binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: x265-12bit
-          path: build/12bit/x265
-          retention-days: 3
-
-  build-multilib:
-    name: "Build Multi-lib (8+10+12 bit)"
-    runs-on: ubuntu-22.04
-    timeout-minutes: 45
-    needs: [build-8bit, build-10bit, build-12bit]
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          persist-credentials: false
-          allow-unsafe-pr-checkout: true
-
-      - name: Cache ccache
-        uses: actions/cache@v5
-        with:
-          path: ~/.ccache
-          key: ccache-multilib-${{ runner.os }}-${{ github.event.pull_request.number && 'pr' || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
-          restore-keys: |
-            ${{ github.event.pull_request.number && format('ccache-multilib-{0}-pr-', runner.os) || '' }}
-            ccache-multilib-${{ runner.os }}-master-
-
-      - name: Cache apt packages
-        uses: actions/cache@v5
-        with:
-          path: /home/runner/apt-archives
-          key: apt-build-${{ runner.os }}-v2
-          restore-keys: apt-build-${{ runner.os }}-v2
-      - name: Pre-populate apt cache
-        run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq build-essential cmake nasm ccache libnuma-dev
-
-      - name: Prepare apt cache
-        if: always()
-        run: |
-          mkdir -p /home/runner/apt-archives
-          cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
-
-      - name: Build 12-bit component (no CLI/API export)
+      # ── multilib components (parallel legs of this same matrix) ────────────
+      - name: Build multilib 12-bit component
+        if: matrix.variant == 'multilib-12bit-component'
         run: |
           export PATH="/usr/lib/ccache:$PATH"
           mkdir -p build/multilib/12bit && cd build/multilib/12bit
@@ -650,7 +529,8 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           make -j$(nproc)
 
-      - name: Build 10-bit component (no CLI/API export)
+      - name: Build multilib 10-bit component
+        if: matrix.variant == 'multilib-10bit-component'
         run: |
           export PATH="/usr/lib/ccache:$PATH"
           mkdir -p build/multilib/10bit && cd build/multilib/10bit
@@ -665,7 +545,110 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           make -j$(nproc)
 
-      - name: Build 8-bit multilib (links all three)
+      - name: Upload 8-bit artifact
+        if: matrix.variant == '8bit'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-linux-8bit${{ matrix.config == 'Debug' && '-debug' || '' }}
+          path: build/8bit/x265
+          retention-days: 3
+
+      - name: Upload 8-bit library artifact
+        if: matrix.variant == '8bit' && matrix.config == 'Release' && github.event_name != 'pull_request_target'
+        uses: actions/upload-artifact@v7
+        with:
+          name: lib-linux-8bit
+          path: build/8bit/libx265.a
+          retention-days: 3
+
+      - name: Upload 10-bit artifact
+        if: matrix.variant == '10bit'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-linux-10bit${{ matrix.config == 'Debug' && '-debug' || '' }}
+          path: build/10bit/x265
+          retention-days: 3
+
+      - name: Upload 12-bit artifact
+        if: matrix.variant == '12bit'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-linux-12bit${{ matrix.config == 'Debug' && '-debug' || '' }}
+          path: build/12bit/x265
+          retention-days: 3
+
+      - name: Upload multilib 12-bit component lib
+        if: matrix.variant == 'multilib-12bit-component'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-linux-multilib-12bit-lib
+          path: build/multilib/12bit/libx265.a
+          retention-days: 3
+
+      - name: Upload multilib 10-bit component lib
+        if: matrix.variant == 'multilib-10bit-component'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-linux-multilib-10bit-lib
+          path: build/multilib/10bit/libx265.a
+          retention-days: 3
+
+  build-linux-multilib:
+    name: "Build Linux (multilib, linked)"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    needs: build-linux
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: ccache-linux-multilib-8bit-linked-${{ github.event.pull_request.number && format('pr{0}', github.event.pull_request.number) || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
+          restore-keys: |
+            ${{ github.event.pull_request.number && format('ccache-linux-multilib-8bit-linked-pr{0}-', github.event.pull_request.number) || '' }}
+            ccache-linux-multilib-8bit-linked-master-
+
+      - name: Cache apt packages
+        uses: actions/cache@v5
+        with:
+          path: /home/runner/apt-archives
+          key: apt-build-linux-v2
+          restore-keys: apt-build-linux-v2
+      - name: Pre-populate apt cache
+        run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq build-essential cmake nasm ccache libnuma-dev
+
+      - name: Prepare apt cache
+        if: always()
+        run: |
+          mkdir -p /home/runner/apt-archives
+          cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
+
+      - name: Download 12-bit component lib
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-linux-multilib-12bit-lib
+          path: build/multilib/12bit
+
+      - name: Download 10-bit component lib
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-linux-multilib-10bit-lib
+          path: build/multilib/10bit
+
+      - name: Build multilib 8-bit (linked)
         run: |
           export PATH="/usr/lib/ccache:$PATH"
           mkdir -p build/multilib/8bit && cd build/multilib/8bit
@@ -683,51 +666,255 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           make -j$(nproc)
-          test -f x265 && echo "Multi-lib CLI OK"
+          test -f x265 && echo "Multilib CLI OK"
           ./x265 --version
 
-      - name: Upload artifacts
-        if: github.event_name != 'pull_request_target'
+      - name: Upload multilib artifact
         uses: actions/upload-artifact@v7
         with:
-          name: x265-multilib
+          name: x265-linux-multilib
           path: |
             build/multilib/8bit/x265
             build/multilib/8bit/libx265.so*
-            build/multilib/8bit/libx265.a
           retention-days: 3
 
-  # ───────────────────────────────────────────────────────────────────────────
-  # Phase 2 – Tests + Smoke Tests (parallel; each depends only on the binary it needs)
-  # Functional test jobs each write a per-job Markdown table to GITHUB_STEP_SUMMARY
-  # so results are visible immediately on the individual job page.
-  # Smoke tests (PR only) run Linux and Windows build matrix against a private
-  # test harness with golden output validation.
-  # ───────────────────────────────────────────────────────────────────────────
-
-  test-cli-presets:
-    name: "Test CLI - All Presets & Tune Modes"
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    needs: build-8bit
+  build-macos:
+    name: "Build macOS (${{ matrix.variant }})"
+    runs-on: macos-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [8bit, 10bit, 12bit, multilib]
     steps:
-      - name: Download 8-bit binary
-        uses: actions/download-artifact@v8
+      - uses: actions/checkout@v6
         with:
-          name: x265-8bit
-          path: dist
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: ccache-macos-${{ matrix.variant }}-${{ github.event.pull_request.number && format('pr{0}', github.event.pull_request.number) || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
+          restore-keys: |
+            ${{ github.event.pull_request.number && format('ccache-macos-{0}-pr{1}-', matrix.variant, github.event.pull_request.number) || '' }}
+            ccache-macos-${{ matrix.variant }}-master-
+
+      - name: Install build dependencies
+        run: |
+          brew untap aws/tap || true
+          brew install ccache
+
+      - name: Log toolchain versions
+        run: |
+          echo "=== Apple Clang ==="
+          clang --version
+          echo "=== ccache ==="
+          ccache --version | head -1
+          echo "=== NASM ==="
+          if command -v nasm >/dev/null 2>&1; then
+            nasm -v
+          else
+            echo "nasm not installed — not required on this architecture (${{ runner.arch }}); x265 uses AArch64 NEON assembly compiled via clang, not NASM, on Apple Silicon"
+          fi
+
+      # ── 8-bit ──────────────────────────────────────────────────────────────
+      - name: Build 8-bit
+        if: matrix.variant == '8bit'
+        run: |
+          export PATH="$(brew --prefix ccache)/libexec:$PATH"
+          mkdir -p build/8bit && cd build/8bit
+          cmake ../../source \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_SHARED=OFF \
+            -DENABLE_CLI=ON \
+            -DENABLE_ASSEMBLY=ON \
+            -DENABLE_TESTS=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          make -j$(sysctl -n hw.logicalcpu)
+          test -f x265      && echo "8-bit CLI OK"
+          test -f libx265.a && echo "8-bit static lib OK"
+          ./x265 --version
+          echo "--- Unit tests ---"
+          ./test/TestBench
+
+      # ── 10-bit ─────────────────────────────────────────────────────────────
+      - name: Build 10-bit
+        if: matrix.variant == '10bit'
+        run: |
+          export PATH="$(brew --prefix ccache)/libexec:$PATH"
+          mkdir -p build/10bit && cd build/10bit
+          cmake ../../source \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DHIGH_BIT_DEPTH=ON \
+            -DENABLE_SHARED=OFF \
+            -DENABLE_CLI=ON \
+            -DENABLE_ASSEMBLY=ON \
+            -DENABLE_TESTS=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          make -j$(sysctl -n hw.logicalcpu)
+          test -f x265 && echo "10-bit CLI OK"
+          ./x265 --version
+          ./test/TestBench
+
+      # ── 12-bit ─────────────────────────────────────────────────────────────
+      - name: Build 12-bit
+        if: matrix.variant == '12bit'
+        run: |
+          export PATH="$(brew --prefix ccache)/libexec:$PATH"
+          mkdir -p build/12bit && cd build/12bit
+          cmake ../../source \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DHIGH_BIT_DEPTH=ON \
+            -DMAIN12=ON \
+            -DENABLE_SHARED=OFF \
+            -DENABLE_CLI=ON \
+            -DENABLE_ASSEMBLY=ON \
+            -DENABLE_TESTS=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          make -j$(sysctl -n hw.logicalcpu)
+          test -f x265 && echo "12-bit CLI OK"
+          ./x265 --version
+          ./test/TestBench
+
+      # ── multilib (8+10+12) ─────────────────────────────────────────────────
+      - name: Build multilib 12-bit component
+        if: matrix.variant == 'multilib'
+        run: |
+          export PATH="$(brew --prefix ccache)/libexec:$PATH"
+          mkdir -p build/multilib/12bit && cd build/multilib/12bit
+          cmake ../../../source \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DHIGH_BIT_DEPTH=ON \
+            -DMAIN12=ON \
+            -DENABLE_SHARED=OFF \
+            -DENABLE_CLI=OFF \
+            -DEXPORT_C_API=OFF \
+            -DENABLE_ASSEMBLY=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          make -j$(sysctl -n hw.logicalcpu)
+
+      - name: Build multilib 10-bit component
+        if: matrix.variant == 'multilib'
+        run: |
+          export PATH="$(brew --prefix ccache)/libexec:$PATH"
+          mkdir -p build/multilib/10bit && cd build/multilib/10bit
+          cmake ../../../source \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DHIGH_BIT_DEPTH=ON \
+            -DENABLE_SHARED=OFF \
+            -DENABLE_CLI=OFF \
+            -DEXPORT_C_API=OFF \
+            -DENABLE_ASSEMBLY=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          make -j$(sysctl -n hw.logicalcpu)
+
+      - name: Build multilib 8-bit (linked)
+        if: matrix.variant == 'multilib'
+        run: |
+          export PATH="$(brew --prefix ccache)/libexec:$PATH"
+          mkdir -p build/multilib/8bit && cd build/multilib/8bit
+          ln -sf ../../multilib/10bit/libx265.a libx265_main10.a
+          ln -sf ../../multilib/12bit/libx265.a libx265_main12.a
+          cmake ../../../source \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_SHARED=ON \
+            -DENABLE_CLI=ON \
+            -DENABLE_ASSEMBLY=ON \
+            -DEXTRA_LIB="x265_main10.a;x265_main12.a" \
+            -DEXTRA_LINK_FLAGS="-L." \
+            -DLINKED_10BIT=ON \
+            -DLINKED_12BIT=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          make -j$(sysctl -n hw.logicalcpu)
+          test -f x265 && echo "macOS Multilib CLI OK"
+          ./x265 --version
+
+      - name: Upload 8-bit artifact
+        if: matrix.variant == '8bit'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-macos-8bit
+          path: build/8bit/x265
+          retention-days: 3
+
+      - name: Upload 10-bit artifact
+        if: matrix.variant == '10bit'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-macos-10bit
+          path: build/10bit/x265
+          retention-days: 3
+
+      - name: Upload 12-bit artifact
+        if: matrix.variant == '12bit'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-macos-12bit
+          path: build/12bit/x265
+          retention-days: 3
+
+      - name: Upload multilib artifact
+        if: matrix.variant == 'multilib'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-macos-multilib
+          path: |
+            build/multilib/8bit/x265
+            build/multilib/8bit/libx265.dylib
+          retention-days: 3
+
+  build-aarch64:
+    name: "Build AArch64 (${{ matrix.variant }}, cross)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [8bit, 10bit, 12bit, multilib]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: ccache-aarch64-${{ matrix.variant }}-${{ github.event.pull_request.number && format('pr{0}', github.event.pull_request.number) || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
+          restore-keys: |
+            ${{ github.event.pull_request.number && format('ccache-aarch64-{0}-pr{1}-', matrix.variant, github.event.pull_request.number) || '' }}
+            ccache-aarch64-${{ matrix.variant }}-master-
 
       - name: Cache apt packages
         uses: actions/cache@v5
         with:
           path: /home/runner/apt-archives
-          key: apt-test-${{ runner.os }}-v2
-          restore-keys: apt-test-${{ runner.os }}-v2
+          key: apt-build-aarch64-v2
+          restore-keys: apt-build-aarch64-v2
       - name: Pre-populate apt cache
         run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
 
-      - name: Install runtime dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libnuma1 ffmpeg
+      - name: Install cross-compile toolchain
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq \
+            gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+            cmake ccache
 
       - name: Prepare apt cache
         if: always()
@@ -735,502 +922,696 @@ jobs:
           mkdir -p /home/runner/apt-archives
           cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
 
-      - name: Run tests
+      # ── 8-bit ──────────────────────────────────────────────────────────────
+      - name: Build 8-bit
+        if: matrix.variant == '8bit'
         run: |
-          chmod +x dist/x265
-          X265=$(pwd)/dist/x265
-          mkdir -p testdata
-          ffmpeg -y -f lavfi -i testsrc=duration=2:size=416x240:rate=30 -pix_fmt yuv420p testdata/test_420_416x240.yuv
-          PASS=0; FAIL=0; TOTAL=0
-          run_x265() {
-            local label="$1"; shift
-            echo "=== $label ==="
-            "$@" 2>&1 | tee /tmp/x265_last.log
-            local rc=${PIPESTATUS[0]}
-            local summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
-            [ -n "$summary" ] && printf "  %-45s | %s\n" "$label" "$summary" >> /tmp/summary.log
-            return $rc
-          }
-          echo "" > /tmp/summary.log
-          for preset in ultrafast superfast veryfast faster fast medium slow slower veryslow; do
-            TOTAL=$((TOTAL + 1))
-            if run_x265 "Preset $preset" $X265 --preset $preset --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out_${preset}.hevc testdata/test_420_416x240.yuv; then
-              PASS=$((PASS + 1))
-            else
-              FAIL=$((FAIL + 1))
-            fi
-            rm -f /tmp/out_${preset}.hevc
-          done
-          for tune in psnr ssim grain fastdecode zerolatency; do
-            TOTAL=$((TOTAL + 1))
-            if run_x265 "Tune $tune" $X265 --preset medium --tune $tune --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out_tune_${tune}.hevc testdata/test_420_416x240.yuv; then
-              PASS=$((PASS + 1))
-            else
-              FAIL=$((FAIL + 1))
-            fi
-            rm -f /tmp/out_tune_${tune}.hevc
-          done
-          echo ""
-          echo "==================== ENCODING SUMMARY ===================="
-          cat /tmp/summary.log 2>/dev/null || true
-          echo "=========================================================="
-          echo "=== Preset/Tune Results $PASS/$TOTAL passed, $FAIL failed ==="
-          mkdir -p summaries && cp /tmp/summary.log summaries/cli-presets.log 2>/dev/null || true
-          test $FAIL -eq 0
+          export PATH="/usr/lib/ccache:$PATH"
+          mkdir -p build/8bit && cd build/8bit
+          cmake ../../source \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_SYSTEM_NAME=Linux \
+            -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+            -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+            -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DENABLE_ASSEMBLY=ON \
+            -DENABLE_SHARED=OFF \
+            -DENABLE_CLI=ON \
+            -DENABLE_TESTS=ON \
+            -DENABLE_LIBNUMA=OFF
+          make -j$(nproc)
+          file x265 | grep -q aarch64 && echo "8-bit AArch64 binary OK"
 
-      - name: Write step summary
-        if: always()
+      # ── 10-bit ─────────────────────────────────────────────────────────────
+      - name: Build 10-bit
+        if: matrix.variant == '10bit'
         run: |
-          {
-            echo "## CLI Presets & Tune Modes"
-            echo ""
-            echo "| Test | Frames | FPS | Bitrate (kb/s) | Avg QP |"
-            echo "|------|-------:|----:|---------------:|-------:|"
-            if [ -f /tmp/summary.log ] && grep -qv '^[[:space:]]*$' /tmp/summary.log 2>/dev/null; then
-              while IFS= read -r line; do
-                [ -z "${line//[[:space:]]/}" ] && continue
-                label=$(echo "$line" | sed 's/^ *//' | cut -d'|' -f1 | sed 's/ *$//')
-                rest=$(echo "$line" | cut -d'|' -f2-)
-                frames=$(echo "$rest" | grep -oP 'encoded \K\d+' || true)
-                fps=$(echo "$rest" | grep -oP '\(\K[\d.]+(?= fps\))' || true)
-                bitrate=$(echo "$rest" | grep -oP '[\d.]+(?= kb/s)' || true)
-                qp=$(echo "$rest" | grep -oP 'Avg QP:\K[\d.]+' || true)
-                echo "| \`${label:-?}\` | ${frames:--} | ${fps:--} | ${bitrate:--} | ${qp:--} |"
-              done < /tmp/summary.log
-            else
-              echo "| _no data_ | | | | |"
-            fi
-            echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
+          export PATH="/usr/lib/ccache:$PATH"
+          mkdir -p build/10bit && cd build/10bit
+          cmake ../../source \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_SYSTEM_NAME=Linux \
+            -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+            -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+            -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DHIGH_BIT_DEPTH=ON \
+            -DENABLE_ASSEMBLY=ON \
+            -DENABLE_SHARED=OFF \
+            -DENABLE_CLI=ON \
+            -DENABLE_TESTS=ON \
+            -DENABLE_LIBNUMA=OFF
+          make -j$(nproc)
+          file x265 | grep -q aarch64 && echo "10-bit AArch64 binary OK"
 
-      - name: Upload summaries
-        if: always() && github.event_name != 'pull_request_target'
+      # ── 12-bit ─────────────────────────────────────────────────────────────
+      - name: Build 12-bit
+        if: matrix.variant == '12bit'
+        run: |
+          export PATH="/usr/lib/ccache:$PATH"
+          mkdir -p build/12bit && cd build/12bit
+          cmake ../../source \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_SYSTEM_NAME=Linux \
+            -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+            -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+            -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DHIGH_BIT_DEPTH=ON \
+            -DMAIN12=ON \
+            -DENABLE_ASSEMBLY=ON \
+            -DENABLE_SHARED=OFF \
+            -DENABLE_CLI=ON \
+            -DENABLE_TESTS=ON \
+            -DENABLE_LIBNUMA=OFF
+          make -j$(nproc)
+          file x265 | grep -q aarch64 && echo "12-bit AArch64 binary OK"
+
+      # ── multilib (8+10+12) ─────────────────────────────────────────────────
+      - name: Build multilib 12-bit component
+        if: matrix.variant == 'multilib'
+        run: |
+          export PATH="/usr/lib/ccache:$PATH"
+          mkdir -p build/multilib/12bit && cd build/multilib/12bit
+          cmake ../../../source \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_SYSTEM_NAME=Linux \
+            -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+            -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+            -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DHIGH_BIT_DEPTH=ON \
+            -DMAIN12=ON \
+            -DENABLE_SHARED=OFF \
+            -DENABLE_CLI=OFF \
+            -DEXPORT_C_API=OFF \
+            -DENABLE_ASSEMBLY=ON \
+            -DENABLE_LIBNUMA=OFF
+          make -j$(nproc)
+
+      - name: Build multilib 10-bit component
+        if: matrix.variant == 'multilib'
+        run: |
+          export PATH="/usr/lib/ccache:$PATH"
+          mkdir -p build/multilib/10bit && cd build/multilib/10bit
+          cmake ../../../source \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_SYSTEM_NAME=Linux \
+            -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+            -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+            -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DHIGH_BIT_DEPTH=ON \
+            -DENABLE_SHARED=OFF \
+            -DENABLE_CLI=OFF \
+            -DEXPORT_C_API=OFF \
+            -DENABLE_ASSEMBLY=ON \
+            -DENABLE_LIBNUMA=OFF
+          make -j$(nproc)
+
+      - name: Build multilib 8-bit (linked)
+        if: matrix.variant == 'multilib'
+        run: |
+          export PATH="/usr/lib/ccache:$PATH"
+          mkdir -p build/multilib/8bit && cd build/multilib/8bit
+          ln -sf ../../multilib/10bit/libx265.a libx265_main10.a
+          ln -sf ../../multilib/12bit/libx265.a libx265_main12.a
+          cmake ../../../source \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_SYSTEM_NAME=Linux \
+            -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+            -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+            -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DENABLE_SHARED=ON \
+            -DENABLE_CLI=ON \
+            -DENABLE_ASSEMBLY=ON \
+            -DEXTRA_LIB="x265_main10.a;x265_main12.a" \
+            -DEXTRA_LINK_FLAGS="-L." \
+            -DLINKED_10BIT=ON \
+            -DLINKED_12BIT=ON \
+            -DENABLE_LIBNUMA=OFF
+          make -j$(nproc)
+          file x265 | grep -q aarch64 && echo "AArch64 Multilib CLI OK"
+
+      - name: Upload 8-bit artifact
+        if: matrix.variant == '8bit'
         uses: actions/upload-artifact@v7
         with:
-          name: summaries-cli-presets
-          path: summaries/*.log
+          name: x265-aarch64-8bit
+          path: build/8bit/x265
           retention-days: 3
 
-  test-rate-control:
-    name: "Test Rate Control Modes"
+      - name: Upload 10-bit artifact
+        if: matrix.variant == '10bit'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-aarch64-10bit
+          path: build/10bit/x265
+          retention-days: 3
+
+      - name: Upload 12-bit artifact
+        if: matrix.variant == '12bit'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-aarch64-12bit
+          path: build/12bit/x265
+          retention-days: 3
+
+      - name: Upload multilib artifact
+        if: matrix.variant == 'multilib'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-aarch64-multilib
+          path: |
+            build/multilib/8bit/x265
+            build/multilib/8bit/libx265.so*
+          retention-days: 3
+
+  build-windows:
+    name: "Build Windows (${{ matrix.variant }}, ${{ matrix.config }})"
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      SCCACHE_DIR: ${{ github.workspace }}\sccache_cache
+      SCCACHE_CACHE_SIZE: 2G
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [8bit, 10bit, 12bit]
+        config: [Release, Debug]
+        # Multilib components — Release only, run in parallel with every leg above.
+        include:
+          - variant: multilib-12bit-component
+            config: Release
+          - variant: multilib-10bit-component
+            config: Release
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
+
+      - name: Cache sccache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-windows-${{ matrix.variant }}-${{ matrix.config }}-${{ github.event.pull_request.number && format('pr{0}', github.event.pull_request.number) || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
+          restore-keys: |
+            ${{ github.event.pull_request.number && format('sccache-windows-{0}-{1}-pr{2}-', matrix.variant, matrix.config, github.event.pull_request.number) || '' }}
+            sccache-windows-${{ matrix.variant }}-${{ matrix.config }}-master-
+
+      - name: Install sccache
+        shell: pwsh
+        env:
+          SCCACHE_VERSION: "0.17.0"
+        run: |
+          $url = "https://github.com/mozilla/sccache/releases/download/v$($env:SCCACHE_VERSION)/sccache-v$($env:SCCACHE_VERSION)-x86_64-pc-windows-msvc.tar.gz"
+          Invoke-WebRequest -Uri $url -OutFile sccache.tar.gz
+          tar -xzf sccache.tar.gz
+          $sccacheDir = (Get-ChildItem -Directory -Filter "sccache-*").FullName
+          echo "$sccacheDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & "$sccacheDir\sccache.exe" --start-server
+
+      - name: Install nasm
+        shell: pwsh
+        run: |
+          choco install nasm -y
+          # Ensure nasm is on PATH for cmd subprocesses
+          $nasmPath = "C:\Program Files\NASM"
+          if (Test-Path $nasmPath) {
+            echo "$nasmPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            [System.Environment]::SetEnvironmentVariable("PATH", "$nasmPath;$env:PATH", "Process")
+          }
+
+      # ── 8-bit ──────────────────────────────────────────────────────────────
+      - name: Build 8-bit
+        if: matrix.variant == '8bit'
+        shell: pwsh
+        run: |
+          $nasmPath = "C:\Program Files\NASM"
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $vcvars = "$vsPath\VC\Auxiliary\Build\vcvars64.bat"
+          cmd /c "`"$vcvars`" && set PATH=$nasmPath;%PATH% && cmake -S source -B build\8bit -DENABLE_SHARED=OFF -DENABLE_CLI=ON -DENABLE_ASSEMBLY=ON -DENABLE_TESTS=ON -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache && cmake --build build\8bit --config ${{ matrix.config }} -j"
+          if (!(Test-Path "build\8bit\${{ matrix.config }}\x265.exe")) { exit 1 }
+          Write-Host "8-bit CLI OK (${{ matrix.config }})"
+          & "build\8bit\${{ matrix.config }}\x265.exe" --version
+          Write-Host "--- Unit tests ---"
+          & "build\8bit\test\${{ matrix.config }}\TestBench.exe"
+
+      # ── 10-bit ─────────────────────────────────────────────────────────────
+      - name: Build 10-bit
+        if: matrix.variant == '10bit'
+        shell: pwsh
+        run: |
+          $nasmPath = "C:\Program Files\NASM"
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $vcvars = "$vsPath\VC\Auxiliary\Build\vcvars64.bat"
+          cmd /c "`"$vcvars`" && set PATH=$nasmPath;%PATH% && cmake -S source -B build\10bit -DHIGH_BIT_DEPTH=ON -DENABLE_SHARED=OFF -DENABLE_CLI=ON -DENABLE_ASSEMBLY=ON -DENABLE_TESTS=ON -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache && cmake --build build\10bit --config ${{ matrix.config }} -j"
+          if (!(Test-Path "build\10bit\${{ matrix.config }}\x265.exe")) { exit 1 }
+          Write-Host "10-bit CLI OK (${{ matrix.config }})"
+          & "build\10bit\${{ matrix.config }}\x265.exe" --version
+          & "build\10bit\test\${{ matrix.config }}\TestBench.exe"
+
+      # ── 12-bit ─────────────────────────────────────────────────────────────
+      - name: Build 12-bit
+        if: matrix.variant == '12bit'
+        shell: pwsh
+        run: |
+          $nasmPath = "C:\Program Files\NASM"
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $vcvars = "$vsPath\VC\Auxiliary\Build\vcvars64.bat"
+          cmd /c "`"$vcvars`" && set PATH=$nasmPath;%PATH% && cmake -S source -B build\12bit -DHIGH_BIT_DEPTH=ON -DMAIN12=ON -DENABLE_SHARED=OFF -DENABLE_CLI=ON -DENABLE_ASSEMBLY=ON -DENABLE_TESTS=ON -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache && cmake --build build\12bit --config ${{ matrix.config }} -j"
+          if (!(Test-Path "build\12bit\${{ matrix.config }}\x265.exe")) { exit 1 }
+          Write-Host "12-bit CLI OK (${{ matrix.config }})"
+          & "build\12bit\${{ matrix.config }}\x265.exe" --version
+          & "build\12bit\test\${{ matrix.config }}\TestBench.exe"
+
+      # ── multilib components (parallel legs of this same matrix) ────────────
+      - name: Build multilib 12-bit component
+        if: matrix.variant == 'multilib-12bit-component'
+        shell: pwsh
+        run: |
+          $nasmPath = "C:\Program Files\NASM"
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $vcvars = "$vsPath\VC\Auxiliary\Build\vcvars64.bat"
+          cmd /c "`"$vcvars`" && set PATH=$nasmPath;%PATH% && cmake -S source -B build\multilib\12bit -DCMAKE_BUILD_TYPE=Release -DHIGH_BIT_DEPTH=ON -DMAIN12=ON -DENABLE_SHARED=OFF -DENABLE_CLI=OFF -DEXPORT_C_API=OFF -DENABLE_ASSEMBLY=ON -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache && cmake --build build\multilib\12bit --config Release -j"
+
+      - name: Build multilib 10-bit component
+        if: matrix.variant == 'multilib-10bit-component'
+        shell: pwsh
+        run: |
+          $nasmPath = "C:\Program Files\NASM"
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $vcvars = "$vsPath\VC\Auxiliary\Build\vcvars64.bat"
+          cmd /c "`"$vcvars`" && set PATH=$nasmPath;%PATH% && cmake -S source -B build\multilib\10bit -DCMAKE_BUILD_TYPE=Release -DHIGH_BIT_DEPTH=ON -DENABLE_SHARED=OFF -DENABLE_CLI=OFF -DEXPORT_C_API=OFF -DENABLE_ASSEMBLY=ON -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache && cmake --build build\multilib\10bit --config Release -j"
+
+      - name: Upload 8-bit artifact
+        if: matrix.variant == '8bit'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-windows-8bit${{ matrix.config == 'Debug' && '-debug' || '' }}
+          path: build/8bit/${{ matrix.config }}/x265.exe
+          retention-days: 3
+
+      - name: Upload 10-bit artifact
+        if: matrix.variant == '10bit'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-windows-10bit${{ matrix.config == 'Debug' && '-debug' || '' }}
+          path: build/10bit/${{ matrix.config }}/x265.exe
+          retention-days: 3
+
+      - name: Upload 12-bit artifact
+        if: matrix.variant == '12bit'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-windows-12bit${{ matrix.config == 'Debug' && '-debug' || '' }}
+          path: build/12bit/${{ matrix.config }}/x265.exe
+          retention-days: 3
+
+      - name: Upload multilib 12-bit component lib
+        if: matrix.variant == 'multilib-12bit-component'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-windows-multilib-12bit-lib
+          path: build/multilib/12bit/Release/x265-static.lib
+          retention-days: 3
+
+      - name: Upload multilib 10-bit component lib
+        if: matrix.variant == 'multilib-10bit-component'
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-windows-multilib-10bit-lib
+          path: build/multilib/10bit/Release/x265-static.lib
+          retention-days: 3
+
+      - name: Show sccache stats
+        if: always()
+        shell: pwsh
+        continue-on-error: true
+        run: sccache --show-stats
+
+  build-windows-multilib:
+    name: "Build Windows (multilib, linked)"
+    runs-on: windows-latest
+    timeout-minutes: 60
+    needs: build-windows
+    env:
+      SCCACHE_DIR: ${{ github.workspace }}\sccache_cache
+      SCCACHE_CACHE_SIZE: 2G
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
+
+      - name: Cache sccache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-windows-multilib-8bit-linked-${{ github.event.pull_request.number && format('pr{0}', github.event.pull_request.number) || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
+          restore-keys: |
+            ${{ github.event.pull_request.number && format('sccache-windows-multilib-8bit-linked-pr{0}-', github.event.pull_request.number) || '' }}
+            sccache-windows-multilib-8bit-linked-master-
+
+      - name: Install sccache
+        shell: pwsh
+        env:
+          SCCACHE_VERSION: "0.17.0"
+        run: |
+          $url = "https://github.com/mozilla/sccache/releases/download/v$($env:SCCACHE_VERSION)/sccache-v$($env:SCCACHE_VERSION)-x86_64-pc-windows-msvc.tar.gz"
+          Invoke-WebRequest -Uri $url -OutFile sccache.tar.gz
+          tar -xzf sccache.tar.gz
+          $sccacheDir = (Get-ChildItem -Directory -Filter "sccache-*").FullName
+          echo "$sccacheDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & "$sccacheDir\sccache.exe" --start-server
+
+      - name: Install nasm
+        shell: pwsh
+        run: |
+          choco install nasm -y
+          $nasmPath = "C:\Program Files\NASM"
+          if (Test-Path $nasmPath) {
+            echo "$nasmPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            [System.Environment]::SetEnvironmentVariable("PATH", "$nasmPath;$env:PATH", "Process")
+          }
+
+      - name: Download 12-bit component lib
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-windows-multilib-12bit-lib
+          path: build/multilib/12bit/Release
+
+      - name: Download 10-bit component lib
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-windows-multilib-10bit-lib
+          path: build/multilib/10bit/Release
+
+      - name: Build multilib 8-bit (linked)
+        shell: pwsh
+        run: |
+          $nasmPath = "C:\Program Files\NASM"
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $vcvars = "$vsPath\VC\Auxiliary\Build\vcvars64.bat"
+          New-Item -ItemType Directory -Force -Path "build\multilib\8bit" | Out-Null
+          Copy-Item "build\multilib\10bit\Release\x265-static.lib" "build\multilib\8bit\x265_main10.lib" -Force -ErrorAction SilentlyContinue
+          Copy-Item "build\multilib\12bit\Release\x265-static.lib" "build\multilib\8bit\x265_main12.lib" -Force -ErrorAction SilentlyContinue
+          $cacheFile = "build\multilib\8bit\init.cmake"
+          @"
+          set(EXTRA_LIB "x265_main10.lib;x265_main12.lib" CACHE STRING "" FORCE)
+          set(EXTRA_LINK_FLAGS "/LIBPATH:." CACHE STRING "" FORCE)
+          set(LINKED_10BIT ON CACHE BOOL "" FORCE)
+          set(LINKED_12BIT ON CACHE BOOL "" FORCE)
+          "@ | Set-Content $cacheFile
+              cmd /c "`"$vcvars`" && set PATH=$nasmPath;%PATH% && cmake -S source -B build\multilib\8bit -C build\multilib\8bit\init.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_SHARED=ON -DENABLE_CLI=ON -DENABLE_ASSEMBLY=ON -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache && cmake --build build\multilib\8bit --config Release -j"
+              if (!(Test-Path "build\multilib\8bit\Release\x265.exe")) { exit 1 }
+              Write-Host "Multilib CLI OK"
+              & "build\multilib\8bit\Release\x265.exe" --version
+
+      - name: Upload multilib artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-windows-multilib
+          path: |
+            build/multilib/8bit/Release/x265.exe
+            build/multilib/8bit/Release/libx265.dll
+          retention-days: 3
+
+      - name: Show sccache stats
+        if: always()
+        shell: pwsh
+        continue-on-error: true
+        run: sccache --show-stats
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Phase 2 – Tests (parallel matrix per test category, per platform)
+  # Each test job downloads that platform's binaries and runs one category of
+  # functional tests, writing a per-job Markdown table to GITHUB_STEP_SUMMARY.
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  test-linux:
+    name: "Test Linux (${{ matrix.category }})"
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    needs: build-8bit
+    timeout-minutes: 60
+    needs: build-linux
+    strategy:
+      fail-fast: false
+      matrix:
+        category: [presets-tune, rate-control, encoding-features, analysis-reuse, real-world, threading, hbd]
     steps:
       - name: Download 8-bit binary
         uses: actions/download-artifact@v8
         with:
-          name: x265-8bit
-          path: dist
+          name: x265-linux-8bit
+          path: dist/8bit
+
+      - name: Download 10-bit binary
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-linux-10bit
+          path: dist/10bit
+
+      - name: Download 12-bit binary
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-linux-12bit
+          path: dist/12bit
 
       - name: Cache apt packages
         uses: actions/cache@v5
         with:
           path: /home/runner/apt-archives
-          key: apt-test-${{ runner.os }}-v2
-          restore-keys: apt-test-${{ runner.os }}-v2
-      - name: Pre-populate apt cache
-        run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
-
-      - name: Install runtime dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libnuma1 ffmpeg
-
-      - name: Prepare apt cache
-        if: always()
-        run: |
-          mkdir -p /home/runner/apt-archives
-          cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
-
-      - name: Run tests
-        run: |
-          chmod +x dist/x265
-          X265=$(pwd)/dist/x265
-          mkdir -p testdata
-          ffmpeg -y -f lavfi -i testsrc=duration=3:size=832x480:rate=30 -pix_fmt yuv420p testdata/test_420_832x480.yuv
-          FAIL=0
-          run_x265() {
-            local label="$1"; shift
-            echo "=== $label ==="
-            "$@" 2>&1 | tee /tmp/x265_last.log
-            local rc=${PIPESTATUS[0]}
-            local summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
-            [ -n "$summary" ] && printf "  %-45s | %s\n" "$label" "$summary" >> /tmp/summary.log
-            return $rc
-          }
-          echo "" > /tmp/summary.log
-          run_x265 "CRF Mode"                   $X265 --preset medium --crf 22 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out_crf.hevc testdata/test_420_832x480.yuv             || FAIL=$((FAIL+1))
-          run_x265 "CQP Mode"                   $X265 --preset medium --qp 28 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out_cqp.hevc testdata/test_420_832x480.yuv              || FAIL=$((FAIL+1))
-          run_x265 "ABR Mode"                   $X265 --preset medium --bitrate 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out_abr.hevc testdata/test_420_832x480.yuv   || FAIL=$((FAIL+1))
-          run_x265 "VBV Constrained"            $X265 --preset medium --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out_vbv.hevc testdata/test_420_832x480.yuv    || FAIL=$((FAIL+1))
-          run_x265 "Strict CBR"                 $X265 --preset medium --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 --strict-cbr -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out_cbr.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "CRF + VBV"                  $X265 --preset medium --crf 22 --vbv-maxrate 2000 --vbv-bufsize 3000 --crf-max 32 --crf-min 18 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out_crf_vbv.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "Two-pass ABR pass1"         $X265 --preset medium --bitrate 1000 --pass 1 -F4 --input-res 832x480 --fps 30 --frames 60 -o /dev/null testdata/test_420_832x480.yuv                || FAIL=$((FAIL+1))
-          run_x265 "Two-pass ABR pass2"         $X265 --preset medium --bitrate 1000 --pass 2 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out_2pass.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "Multi-pass Opt Analysis p1" $X265 --preset medium --bitrate 1000 --pass 1 --multi-pass-opt-analysis --input-res 832x480 --fps 30 --frames 60 -o /dev/null testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "Multi-pass Opt Analysis p2" $X265 --preset medium --bitrate 1000 --pass 2 --multi-pass-opt-analysis --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out_mp_opt.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          rm -f /tmp/out_*.hevc x265_2pass.log x265_2pass.log.cutree
-          echo ""
-          echo "==================== ENCODING SUMMARY ===================="
-          cat /tmp/summary.log 2>/dev/null || true
-          echo "=========================================================="
-          echo "=== Rate Control Results FAIL=$FAIL ==="
-          mkdir -p summaries && cp /tmp/summary.log summaries/rate-control.log 2>/dev/null || true
-          test $FAIL -eq 0
-
-      - name: Write step summary
-        if: always()
-        run: |
-          {
-            echo "## Rate Control Modes"
-            echo ""
-            echo "| Test | Frames | FPS | Bitrate (kb/s) | Avg QP |"
-            echo "|------|-------:|----:|---------------:|-------:|"
-            if [ -f /tmp/summary.log ] && grep -qv '^[[:space:]]*$' /tmp/summary.log 2>/dev/null; then
-              while IFS= read -r line; do
-                [ -z "${line//[[:space:]]/}" ] && continue
-                label=$(echo "$line" | sed 's/^ *//' | cut -d'|' -f1 | sed 's/ *$//')
-                rest=$(echo "$line" | cut -d'|' -f2-)
-                frames=$(echo "$rest" | grep -oP 'encoded \K\d+' || true)
-                fps=$(echo "$rest" | grep -oP '\(\K[\d.]+(?= fps\))' || true)
-                bitrate=$(echo "$rest" | grep -oP '[\d.]+(?= kb/s)' || true)
-                qp=$(echo "$rest" | grep -oP 'Avg QP:\K[\d.]+' || true)
-                echo "| \`${label:-?}\` | ${frames:--} | ${fps:--} | ${bitrate:--} | ${qp:--} |"
-              done < /tmp/summary.log
-            else
-              echo "| _no data_ | | | | |"
-            fi
-            echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload summaries
-        if: always() && github.event_name != 'pull_request_target'
-        uses: actions/upload-artifact@v7
-        with:
-          name: summaries-rate-control
-          path: summaries/*.log
-          retention-days: 3
-
-  test-encoding-features:
-    name: "Test Encoding Features"
-    runs-on: ubuntu-22.04
-    timeout-minutes: 45
-    needs: build-8bit
-    steps:
-      - name: Download 8-bit binary
-        uses: actions/download-artifact@v8
-        with:
-          name: x265-8bit
-          path: dist
-
-      - name: Cache apt packages
-        uses: actions/cache@v5
-        with:
-          path: /home/runner/apt-archives
-          key: apt-test-${{ runner.os }}-v2
-          restore-keys: apt-test-${{ runner.os }}-v2
-      - name: Pre-populate apt cache
-        run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
-
-      - name: Install runtime dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libnuma1 ffmpeg
-
-      - name: Prepare apt cache
-        if: always()
-        run: |
-          mkdir -p /home/runner/apt-archives
-          cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
-
-      - name: Run tests
-        run: |
-          chmod +x dist/x265
-          X265=$(pwd)/dist/x265
-          mkdir -p testdata
-          ffmpeg -y -f lavfi -i testsrc=duration=2:size=832x480:rate=30 -pix_fmt yuv420p  testdata/test_420_832x480.yuv
-          ffmpeg -y -f lavfi -i testsrc=duration=2:size=416x240:rate=30 -pix_fmt yuv422p  testdata/test_422_416x240.yuv
-          ffmpeg -y -f lavfi -i testsrc=duration=2:size=416x240:rate=30 -pix_fmt yuv444p  testdata/test_444_416x240.yuv
-          ffmpeg -y -f lavfi -i testsrc=duration=2:size=416x240:rate=30 -pix_fmt yuv420p  testdata/test_420_416x240.yuv
-          FAIL=0
-          run_x265() {
-            local label="$1"; shift
-            echo "=== $label ==="
-            "$@" 2>&1 | tee /tmp/x265_last.log
-            local rc=${PIPESTATUS[0]}
-            local summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
-            [ -n "$summary" ] && printf "  %-45s | %s\n" "$label" "$summary" >> /tmp/summary.log
-            return $rc
-          }
-          echo "" > /tmp/summary.log
-          run_x265 "Lossless"          $X265 --preset ultrafast --lossless                                       --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "CU Lossless"       $X265 --preset medium --crf 22 --cu-lossless                              --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          for ctu in 16 32 64; do
-            run_x265 "CTU $ctu"        $X265 --preset medium --ctu $ctu --crf 28                                 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          done
-          for aqmode in 0 3; do
-            run_x265 "AQ Mode $aqmode" $X265 --preset medium --aq-mode $aqmode --crf 28                          --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          done
-          for me in hex umh full; do
-            run_x265 "ME $me"          $X265 --preset medium --me $me --crf 28                                   --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          done
-          run_x265 "SAO + Deblock"     $X265 --preset medium --sao --deblock 2:2 --crf 28                        --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "No SAO/Deblock"    $X265 --preset medium --no-sao --no-deblock --crf 28                      --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Limit SAO"         $X265 --preset medium --limit-sao --crf 28                                --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Weighted P + B"    $X265 --preset medium --weightp --weightb --crf 28                        --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "B-frames 0"        $X265 --preset medium --bframes 0 --crf 28                                --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "B-frames 16"       $X265 --preset medium --bframes 16 --crf 28                               --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Infinite Keyint"   $X265 --preset medium --keyint -1 --crf 28                                --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Short Keyint"      $X265 --preset medium --keyint 10 --min-keyint 5 --crf 28                 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Closed GOP"        $X265 --preset medium --no-open-gop --crf 28                              --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Constrained Intra" $X265 --preset medium --constrained-intra --crf 28                        --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          for rd in 2 5; do
-            run_x265 "RD Level $rd"    $X265 --preset medium --rd $rd --crf 28                                   --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          done
-          for rdoq in 0 2; do
-            run_x265 "RDOQ Level $rdoq" $X265 --preset medium --rdoq-level $rdoq --crf 28                        --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          done
-          run_x265 "Scaling List"      $X265 --preset medium --scaling-list default --crf 28                     --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Noise Reduction"   $X265 --preset medium --nr-intra 500 --nr-inter 300 -F4 --crf 28          --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Psy-RD + Psy-RDOQ" $X265 --preset medium --psy-rd 1.5 --psy-rdoq 1.0 --crf 28              --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "No Psy"            $X265 --preset medium --no-psy-rd --no-psy-rdoq --crf 28                  --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Multiple Slices"   $X265 --preset medium --slices 4 --crf 28                                 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "Temporal Layers"   $X265 --preset medium --temporal-layers 3 --b-adapt 0 --crf 28            --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "HEVC-AQ"           $X265 --preset medium --hevc-aq --no-cutree --crf 28                      --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "HME"               $X265 --preset medium --hme --crf 28                                      --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "Lowpass DCT"       $X265 --preset medium --lowpass-dct --crf 28                              --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Streaming Flags"   $X265 --preset medium --hrd --aud --repeat-headers --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "422 Input"         $X265 --preset medium --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_422_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "444 Input"         $X265 --preset medium --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_444_416x240.yuv || FAIL=$((FAIL+1))
-          rm -f /tmp/out.hevc
-
-          run_x265 "Segment Encoding"  $X265 --preset ultrafast --no-open-gop --chunk-start 10 --chunk-end 50 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-
-          # ── Quality Metrics ──
-          run_x265 "SSIM Metric"   $X265 --preset medium --ssim        --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          grep -qi "ssim" /tmp/x265_last.log || { echo "FAIL: ssim not reported"; FAIL=$((FAIL+1)); }
-          run_x265 "PSNR Metric"   $X265 --preset medium --psnr        --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          grep -qi "psnr" /tmp/x265_last.log || { echo "FAIL: psnr not reported"; FAIL=$((FAIL+1)); }
-          run_x265 "SSIM + PSNR"  $X265 --preset medium --ssim --psnr --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Hash (MD5)"   $X265 --preset medium --hash 1      --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Recon Output" $X265 --preset medium               --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc -r /tmp/recon.yuv testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          test -f /tmp/recon.yuv && echo "Recon file created OK" || { echo "FAIL: recon file missing"; FAIL=$((FAIL+1)); }
-          rm -f /tmp/out.hevc /tmp/recon.yuv
-
-          # ── MCSTF, SBRC & Interlace ──
-          ffmpeg -y -f lavfi -i testsrc=duration=3:size=1920x1080:rate=25 -pix_fmt yuv420p testdata/test_420_1080p.yuv
-          run_x265 "MCSTF slower"          $X265 --preset slower    --crf 24 --mcstf --bframes 5 --frame-threads 1 --no-cutree --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "MCSTF medium"          $X265 --preset medium    --crf 26 --mcstf --bframes 5 --frame-threads 1 --tskip-fast --constrained-intra --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "MCSTF slow"            $X265 --preset slow      --crf 24 --mcstf --bframes 5 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "SBRC slow"             $X265 --preset slow      --crf 26 --sbrc --no-open-gop --keyint 60 --min-keyint 60 --vbv-bufsize 6000 --vbv-maxrate 5000 --temporal-layers 4 --b-adapt 0 --no-cutree --input-res 1920x1080 --fps 25 --frames 50 -o /tmp/out.hevc testdata/test_420_1080p.yuv || FAIL=$((FAIL+1))
-          run_x265 "SBRC superfast"        $X265 --preset superfast --crf 22 --sbrc --no-open-gop --vbv-maxrate 9000 --vbv-bufsize 7500 --keyint 100 --min-keyint 100 --input-res 1920x1080 --fps 25 --frames 50 -o /tmp/out.hevc testdata/test_420_1080p.yuv || FAIL=$((FAIL+1))
-          run_x265 "Interlace TFF"         $X265 --preset faster    --interlace tff --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "Interlace BFF"         $X265 --preset fast      --interlace bff --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "Interlace BFF+weightb" $X265 --preset fast      --interlace bff --weightb --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          rm -f /tmp/out.hevc
-
-          echo ""
-          echo "==================== ENCODING SUMMARY ===================="
-          cat /tmp/summary.log 2>/dev/null || true
-          echo "=========================================================="
-          echo "=== Encoding Features Results FAIL=$FAIL ==="
-          mkdir -p summaries && cp /tmp/summary.log summaries/encoding-features.log 2>/dev/null || true
-          test $FAIL -eq 0
-
-      - name: Write step summary
-        if: always()
-        run: |
-          {
-            echo "## Encoding Features"
-            echo ""
-            echo "| Test | Frames | FPS | Bitrate (kb/s) | Avg QP |"
-            echo "|------|-------:|----:|---------------:|-------:|"
-            if [ -f /tmp/summary.log ] && grep -qv '^[[:space:]]*$' /tmp/summary.log 2>/dev/null; then
-              while IFS= read -r line; do
-                [ -z "${line//[[:space:]]/}" ] && continue
-                label=$(echo "$line" | sed 's/^ *//' | cut -d'|' -f1 | sed 's/ *$//')
-                rest=$(echo "$line" | cut -d'|' -f2-)
-                frames=$(echo "$rest" | grep -oP 'encoded \K\d+' || true)
-                fps=$(echo "$rest" | grep -oP '\(\K[\d.]+(?= fps\))' || true)
-                bitrate=$(echo "$rest" | grep -oP '[\d.]+(?= kb/s)' || true)
-                qp=$(echo "$rest" | grep -oP 'Avg QP:\K[\d.]+' || true)
-                echo "| \`${label:-?}\` | ${frames:--} | ${fps:--} | ${bitrate:--} | ${qp:--} |"
-              done < /tmp/summary.log
-            else
-              echo "| _no data_ | | | | |"
-            fi
-            echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload summaries
-        if: always() && github.event_name != 'pull_request_target'
-        uses: actions/upload-artifact@v7
-        with:
-          name: summaries-encoding-features
-          path: summaries/*.log
-          retention-days: 3
-
-  test-analysis-save-load:
-    name: "Test Analysis Save/Load"
-    runs-on: ubuntu-22.04
-    timeout-minutes: 20
-    needs: build-8bit
-    steps:
-      - name: Download 8-bit binary
-        uses: actions/download-artifact@v8
-        with:
-          name: x265-8bit
-          path: dist
-
-      - name: Cache apt packages
-        uses: actions/cache@v5
-        with:
-          path: /home/runner/apt-archives
-          key: apt-test-${{ runner.os }}-v2
-          restore-keys: apt-test-${{ runner.os }}-v2
-      - name: Pre-populate apt cache
-        run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
-
-      - name: Install runtime dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libnuma1 ffmpeg
-
-      - name: Prepare apt cache
-        if: always()
-        run: |
-          mkdir -p /home/runner/apt-archives
-          cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
-
-      - name: Run tests
-        run: |
-          chmod +x dist/x265
-          X265=$(pwd)/dist/x265
-          mkdir -p testdata
-          ffmpeg -y -f lavfi -i testsrc=duration=4:size=416x240:rate=30 -pix_fmt yuv420p testdata/test_420_416x240.yuv
-          FAIL=0
-          run_x265() {
-            local label="$1"; shift
-            echo "=== $label ==="
-            "$@" 2>&1 | tee /tmp/x265_last.log
-            local rc=${PIPESTATUS[0]}
-            local summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
-            [ -n "$summary" ] && printf "  %-45s | %s\n" "$label" "$summary" >> /tmp/summary.log
-            return $rc
-          }
-          echo "" > /tmp/summary.log
-          run_x265 "Analysis Save (level 2)"  $X265 --preset medium --analysis-save x265_analysis.dat    --analysis-save-reuse-level 2  --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out_save.hevc  testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Analysis Load (level 2)"  $X265 --preset medium --analysis-load x265_analysis.dat    --analysis-load-reuse-level 2  --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out_load.hevc  testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Analysis Save (level 10)" $X265 --preset slow   --analysis-save x265_analysis_10.dat --analysis-save-reuse-level 10 --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out_save10.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "Analysis Load (level 10)" $X265 --preset slow   --analysis-load x265_analysis_10.dat --analysis-load-reuse-level 10 --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out_load10.hevc testdata/test_420_416x240.yuv || FAIL=$((FAIL+1))
-          rm -f /tmp/out_save.hevc /tmp/out_load.hevc /tmp/out_save10.hevc /tmp/out_load10.hevc x265_analysis*.dat
-          echo ""
-          echo "==================== ENCODING SUMMARY ===================="
-          cat /tmp/summary.log 2>/dev/null || true
-          echo "=========================================================="
-          echo "=== Analysis Save/Load Results FAIL=$FAIL ==="
-          mkdir -p summaries && cp /tmp/summary.log summaries/analysis-save-load.log 2>/dev/null || true
-          test $FAIL -eq 0
-
-      - name: Write step summary
-        if: always()
-        run: |
-          {
-            echo "## Analysis Save/Load"
-            echo ""
-            echo "| Test | Frames | FPS | Bitrate (kb/s) | Avg QP |"
-            echo "|------|-------:|----:|---------------:|-------:|"
-            if [ -f /tmp/summary.log ] && grep -qv '^[[:space:]]*$' /tmp/summary.log 2>/dev/null; then
-              while IFS= read -r line; do
-                [ -z "${line//[[:space:]]/}" ] && continue
-                label=$(echo "$line" | sed 's/^ *//' | cut -d'|' -f1 | sed 's/ *$//')
-                rest=$(echo "$line" | cut -d'|' -f2-)
-                frames=$(echo "$rest" | grep -oP 'encoded \K\d+' || true)
-                fps=$(echo "$rest" | grep -oP '\(\K[\d.]+(?= fps\))' || true)
-                bitrate=$(echo "$rest" | grep -oP '[\d.]+(?= kb/s)' || true)
-                qp=$(echo "$rest" | grep -oP 'Avg QP:\K[\d.]+' || true)
-                echo "| \`${label:-?}\` | ${frames:--} | ${fps:--} | ${bitrate:--} | ${qp:--} |"
-              done < /tmp/summary.log
-            else
-              echo "| _no data_ | | | | |"
-            fi
-            echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload summaries
-        if: always() && github.event_name != 'pull_request_target'
-        uses: actions/upload-artifact@v7
-        with:
-          name: summaries-analysis-save-load
-          path: summaries/*.log
-          retention-days: 3
-
-  test-video-and-validation:
-    name: "Test Real-World Video & Bitstream Validation"
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    needs: build-8bit
-    steps:
-      - name: Download 8-bit binary
-        uses: actions/download-artifact@v8
-        with:
-          name: x265-8bit
-          path: dist
-
-      - name: Cache apt packages
-        uses: actions/cache@v5
-        with:
-          path: /home/runner/apt-archives
-          key: apt-test-${{ runner.os }}-v2
-          restore-keys: apt-test-${{ runner.os }}-v2
+          key: apt-test-linux-v2
+          restore-keys: apt-test-linux-v2
       - name: Pre-populate apt cache
         run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
 
       - name: Install runtime dependencies
         run: sudo apt-get update -qq && sudo apt-get install -y -qq libnuma1 ffmpeg wget
 
-      - name: Prepare apt cache
+      - name: Save apt cache
         if: always()
         run: |
           mkdir -p /home/runner/apt-archives
           cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
 
+      - name: Make binaries executable
+        run: |
+          chmod +x dist/8bit/x265 dist/10bit/x265 dist/12bit/x265
+
+      - name: Generate test data
+        run: |
+          mkdir -p testdata
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv420p     testdata/test_8bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=832x480:rate=30  -pix_fmt yuv420p     testdata/test_8bit_832x480.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv422p     testdata/test_422_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv444p     testdata/test_444_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv420p10le testdata/test_10bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=832x480:rate=30  -pix_fmt yuv420p10le testdata/test_10bit_832x480.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv420p12le testdata/test_12bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=1920x1080:rate=25 -pix_fmt yuv420p    testdata/test_8bit_1080p.yuv
+
       - name: Cache xiph.org test videos
         id: cache-videos
         uses: actions/cache@v5
         with:
-          path: testdata
+          path: testdata/xiph
           key: xiph-test-videos-v1
-
-      - name: Download test videos (cache miss only)
+      - name: Download xiph test videos (cache miss only)
         if: steps.cache-videos.outputs.cache-hit != 'true'
         run: |
-          mkdir -p testdata
-          wget -q --tries=3 --timeout=60 -O testdata/bus_cif.y4m   https://media.xiph.org/video/derf/y4m/bus_cif.y4m
-          wget -q --tries=3 --timeout=60 -O testdata/akiyo_cif.y4m https://media.xiph.org/video/derf/y4m/akiyo_cif.y4m
+          mkdir -p testdata/xiph
+          wget -q --tries=3 --timeout=60 -O testdata/xiph/bus_cif.y4m   https://media.xiph.org/video/derf/y4m/bus_cif.y4m
+          wget -q --tries=3 --timeout=60 -O testdata/xiph/akiyo_cif.y4m https://media.xiph.org/video/derf/y4m/akiyo_cif.y4m
 
-      - name: Run tests
+      - name: Define helper
         run: |
-          chmod +x dist/x265
-          X265=$(pwd)/dist/x265
-          mkdir -p testdata artifacts
-          ffmpeg -y -f lavfi -i testsrc=duration=2:size=416x240:rate=30 -pix_fmt yuv420p testdata/test_420_416x240.yuv
-          FAIL=0
-          echo "" > /tmp/summary.log
-          run_x265() {
-            local label="$1"; shift
-            echo "=== $label ==="
-            "$@" 2>&1 | tee /tmp/x265_last.log
-            local rc=${PIPESTATUS[0]}
-            local summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
-            [ -n "$summary" ] && printf "  %-45s | %s\n" "$label" "$summary" >> /tmp/summary.log
-            return $rc
-          }
+          cat > /tmp/run_x265.sh << 'HELPER'
+          #!/usr/bin/env bash
+          label="$1"; shift
+          echo "=== $label ==="
+          "$@" 2>&1 | tee /tmp/x265_last.log
+          rc=${PIPESTATUS[0]}
+          summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
+          [ -n "$summary" ] && printf "%-50s | %s\n" "$label" "$summary" >> /tmp/summary.log
+          exit $rc
+          HELPER
+          chmod +x /tmp/run_x265.sh
 
-          # ── Bitstream Validation ──
+      # ── CLI Presets & Tune modes ────────────────────────────────────────────
+      - name: Test - CLI Presets & Tune Modes
+        if: matrix.category == 'presets-tune'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          PASS=0; FAIL=0; TOTAL=0
+          echo "### Presets" >> /tmp/summary.log
+          for preset in ultrafast superfast veryfast faster fast medium slow slower veryslow; do
+            TOTAL=$((TOTAL + 1))
+            if /tmp/run_x265.sh "Preset $preset" \
+              $X265 --preset $preset --crf 28 \
+              --input-res 416x240 --fps 30 --frames 30 \
+              -o /tmp/out.hevc testdata/test_8bit_416x240.yuv; then
+              PASS=$((PASS + 1))
+            else
+              FAIL=$((FAIL + 1))
+            fi
+            rm -f /tmp/out.hevc
+          done
+          echo "" >> /tmp/summary.log
+          echo "### Tune Modes" >> /tmp/summary.log
+          for tune in psnr ssim grain fastdecode zerolatency; do
+            TOTAL=$((TOTAL + 1))
+            if /tmp/run_x265.sh "Tune $tune" \
+              $X265 --preset medium --tune $tune --crf 28 \
+              --input-res 416x240 --fps 30 --frames 30 \
+              -o /tmp/out.hevc testdata/test_8bit_416x240.yuv; then
+              PASS=$((PASS + 1))
+            else
+              FAIL=$((FAIL + 1))
+            fi
+            rm -f /tmp/out.hevc
+          done
+          echo "=== Preset/Tune Results $PASS/$TOTAL passed, $FAIL failed ==="
+          test $FAIL -eq 0
+
+      # ── Rate Control modes ──────────────────────────────────────────────────
+      - name: Test - Rate Control Modes
+        if: matrix.category == 'rate-control'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          echo "### Rate Control" >> /tmp/summary.log
+          /tmp/run_x265.sh "CRF Mode"                   $X265 --preset medium --crf 22 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "CQP Mode"                   $X265 --preset medium --qp 28  --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "ABR Mode"                   $X265 --preset medium --bitrate 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "VBV Constrained"            $X265 --preset medium --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Strict CBR"                 $X265 --preset medium --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 --strict-cbr -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "CRF + VBV"                  $X265 --preset medium --crf 22 --vbv-maxrate 2000 --vbv-bufsize 3000 --crf-max 32 --crf-min 18 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "2-pass p1"                  $X265 --preset medium --bitrate 1000 --pass 1 -F4 --input-res 832x480 --fps 30 --frames 60 -o /dev/null testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "2-pass p2"                  $X265 --preset medium --bitrate 1000 --pass 2 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
+          /tmp/run_x265.sh "Multi-pass Opt Analysis p1" $X265 --preset medium --bitrate 1000 --pass 1 --multi-pass-opt-analysis --input-res 832x480 --fps 30 --frames 60 -o /dev/null testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "Multi-pass Opt Analysis p2" $X265 --preset medium --bitrate 1000 --pass 2 --multi-pass-opt-analysis --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
+          echo "=== Rate Control Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      # ── Encoding Features ───────────────────────────────────────────────────
+      - name: Test - Encoding Features
+        if: matrix.category == 'encoding-features'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          echo "### Encoding Features" >> /tmp/summary.log
+          /tmp/run_x265.sh "Lossless"           $X265 --preset ultrafast --lossless --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "CU Lossless"        $X265 --preset medium --crf 22 --cu-lossless --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          for ctu in 16 32 64; do
+            /tmp/run_x265.sh "CTU $ctu"         $X265 --preset medium --ctu $ctu --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for aqmode in 0 3; do
+            /tmp/run_x265.sh "AQ Mode $aqmode"  $X265 --preset medium --aq-mode $aqmode --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for me in hex umh full; do
+            /tmp/run_x265.sh "ME $me"           $X265 --preset medium --me $me --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          /tmp/run_x265.sh "SAO + Deblock"      $X265 --preset medium --sao --deblock 2:2 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "No SAO/Deblock"     $X265 --preset medium --no-sao --no-deblock --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Limit SAO"          $X265 --preset medium --limit-sao --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Weighted P+B"       $X265 --preset medium --weightp --weightb --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "B-frames 0"         $X265 --preset medium --bframes 0  --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "B-frames 16"        $X265 --preset medium --bframes 16 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Infinite Keyint"    $X265 --preset medium --keyint -1 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Short Keyint"       $X265 --preset medium --keyint 10 --min-keyint 5 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Closed GOP"         $X265 --preset medium --no-open-gop --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Constrained Intra"  $X265 --preset medium --constrained-intra --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          for rd in 2 5; do
+            /tmp/run_x265.sh "RD Level $rd"     $X265 --preset medium --rd $rd --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for rdoq in 0 2; do
+            /tmp/run_x265.sh "RDOQ Level $rdoq" $X265 --preset medium --rdoq-level $rdoq --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          /tmp/run_x265.sh "Scaling List"       $X265 --preset medium --scaling-list default --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Noise Reduction"    $X265 --preset medium --nr-intra 500 --nr-inter 300 -F4 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Psy-RD + Psy-RDOQ" $X265 --preset medium --psy-rd 1.5 --psy-rdoq 1.0 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "No Psy"             $X265 --preset medium --no-psy-rd --no-psy-rdoq --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Multiple Slices"    $X265 --preset medium --slices 4 --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Temporal Layers"    $X265 --preset medium --temporal-layers 3 --b-adapt 0 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "HEVC-AQ"            $X265 --preset medium --hevc-aq --no-cutree --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "HME"                $X265 --preset medium --hme --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Lowpass DCT"        $X265 --preset medium --lowpass-dct --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Streaming Flags"    $X265 --preset medium --hrd --aud --repeat-headers --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "422 Input"          $X265 --preset medium --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_422_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "444 Input"          $X265 --preset medium --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_444_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Segment Encoding"   $X265 --preset ultrafast --no-open-gop --chunk-start 10 --chunk-end 50 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "" >> /tmp/summary.log
+          echo "### Quality Metrics" >> /tmp/summary.log
+          /tmp/run_x265.sh "SSIM Metric"        $X265 --preset medium --ssim        --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1))
+          grep -qi "ssim" /tmp/x265_last.log || { echo "FAIL: ssim not reported"; FAIL=$((FAIL+1)); }
+          rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "PSNR Metric"        $X265 --preset medium --psnr        --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1))
+          grep -qi "psnr" /tmp/x265_last.log || { echo "FAIL: psnr not reported"; FAIL=$((FAIL+1)); }
+          rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "SSIM + PSNR"        $X265 --preset medium --ssim --psnr --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Hash (MD5)"         $X265 --preset medium --hash 1      --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Recon Output"       $X265 --preset medium               --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc -r /tmp/recon.yuv testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1))
+          test -f /tmp/recon.yuv && echo "Recon file created OK" || { echo "FAIL: recon file missing"; FAIL=$((FAIL+1)); }
+          rm -f /tmp/out.hevc /tmp/recon.yuv
+          echo "" >> /tmp/summary.log
+          echo "### MCSTF, SBRC & Interlace" >> /tmp/summary.log
+          /tmp/run_x265.sh "MCSTF slower"          $X265 --preset slower    --crf 24 --mcstf --bframes 5 --frame-threads 1 --no-cutree --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "MCSTF medium"          $X265 --preset medium    --crf 26 --mcstf --bframes 5 --frame-threads 1 --tskip-fast --constrained-intra --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "MCSTF slow"            $X265 --preset slow      --crf 24 --mcstf --bframes 5 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "SBRC slow"             $X265 --preset slow      --crf 26 --sbrc --no-open-gop --keyint 60 --min-keyint 60 --vbv-bufsize 6000 --vbv-maxrate 5000 --temporal-layers 4 --b-adapt 0 --no-cutree --input-res 1920x1080 --fps 25 --frames 50 -o /tmp/out.hevc testdata/test_8bit_1080p.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "SBRC superfast"        $X265 --preset superfast --crf 22 --sbrc --no-open-gop --vbv-maxrate 9000 --vbv-bufsize 7500 --keyint 100 --min-keyint 100 --input-res 1920x1080 --fps 25 --frames 50 -o /tmp/out.hevc testdata/test_8bit_1080p.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Interlace TFF"         $X265 --preset faster    --interlace tff --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Interlace BFF"         $X265 --preset fast      --interlace bff --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Interlace BFF+weightb" $X265 --preset fast      --interlace bff --weightb --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "=== Encoding Features Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      # ── Analysis Save/Load ──────────────────────────────────────────────────
+      - name: Test - Analysis Save/Load
+        if: matrix.category == 'analysis-reuse'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          echo "### Analysis Save/Load" >> /tmp/summary.log
+          /tmp/run_x265.sh "Analysis Save (level 2)"  $X265 --preset medium --analysis-save x265_analysis.dat    --analysis-save-reuse-level 2  --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Analysis Load (level 2)"  $X265 --preset medium --analysis-load x265_analysis.dat    --analysis-load-reuse-level 2  --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Analysis Save (level 10)" $X265 --preset slow   --analysis-save x265_analysis_10.dat --analysis-save-reuse-level 10 --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Analysis Load (level 10)" $X265 --preset slow   --analysis-load x265_analysis_10.dat --analysis-load-reuse-level 10 --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_analysis*.dat
+          echo "=== Analysis Save/Load Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      # ── Real-world Video & Bitstream Validation ─────────────────────────────
+      - name: Test - Real-World Video & Bitstream Validation
+        if: matrix.category == 'real-world'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          mkdir -p artifacts
+          echo "### Bitstream Validation" >> /tmp/summary.log
           validate_encode() {
             local label="$1"; shift
             echo "=== $label ==="
             local outfile="/tmp/validate_${RANDOM}.hevc"
-            $X265 "$@" -o "$outfile" testdata/test_420_416x240.yuv 2>&1 | tee /tmp/x265_last.log
+            $X265 "$@" -o "$outfile" testdata/test_8bit_416x240.yuv 2>&1 | tee /tmp/x265_last.log
             local rc=${PIPESTATUS[0]}
             local summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
-            [ -n "$summary" ] && printf "  %-45s | %s\n" "$label" "$summary" >> /tmp/summary.log
+            [ -n "$summary" ] && printf "%-50s | %s\n" "$label" "$summary" >> /tmp/summary.log
             if [ $rc -eq 0 ]; then
               if ffprobe -v error -show_entries stream=codec_name "$outfile" 2>&1 | grep -q hevc; then
                 echo "PASS: $label (encode + probe)"
@@ -1255,16 +1636,16 @@ jobs:
           validate_encode "HRD compliant" --preset medium   --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 --hrd --aud --repeat-headers -F4 --input-res 416x240 --fps 30 --frames 30
           validate_encode "Closed GOP"    --preset medium   --no-open-gop --keyint 10 --crf 28 --input-res 416x240 --fps 30 --frames 30
           validate_encode "Zero-latency"  --preset medium   --tune zerolatency --crf 28 --input-res 416x240 --fps 30 --frames 30
-
-          # ── Real-World Video (Y4M) ──
-          run_x265 "bus ultrafast CRF 28"     $X265 --preset ultrafast --crf 28 --ssim --psnr --frames 150 -o artifacts/bus_ultrafast_crf28.hevc     testdata/bus_cif.y4m   || FAIL=$((FAIL+1))
-          run_x265 "bus medium CRF 22"        $X265 --preset medium   --crf 22 --ssim --psnr --frames 150 -o artifacts/bus_medium_crf22.hevc         testdata/bus_cif.y4m   || FAIL=$((FAIL+1))
-          run_x265 "bus slow ABR 1000k"       $X265 --preset slow     --bitrate 1000 --vbv-maxrate 1500 --vbv-bufsize 2000 -F4 --ssim --psnr --frames 150 -o artifacts/bus_slow_abr1000k.hevc testdata/bus_cif.y4m || FAIL=$((FAIL+1))
-          run_x265 "bus veryslow tune grain"  $X265 --preset veryslow --tune grain --crf 20 --ssim --psnr --frames 150 -o artifacts/bus_veryslow_grain.hevc testdata/bus_cif.y4m || FAIL=$((FAIL+1))
-          run_x265 "akiyo medium CRF 22"      $X265 --preset medium   --crf 22 --ssim --psnr --frames 300 -o artifacts/akiyo_medium_crf22.hevc       testdata/akiyo_cif.y4m || FAIL=$((FAIL+1))
-          run_x265 "akiyo slow VBV 500k CBR"  $X265 --preset slow     --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 --strict-cbr -F4 --ssim --psnr --frames 300 -o artifacts/akiyo_slow_vbv500k.hevc testdata/akiyo_cif.y4m || FAIL=$((FAIL+1))
-          run_x265 "akiyo veryslow CRF 18"    $X265 --preset veryslow --crf 18 --ssim --psnr --frames 300 -o artifacts/akiyo_veryslow_crf18.hevc     testdata/akiyo_cif.y4m || FAIL=$((FAIL+1))
-          echo "=== Validate HEVC artifacts with ffprobe ==="
+          echo "" >> /tmp/summary.log
+          echo "### Real-World Video (Y4M)" >> /tmp/summary.log
+          /tmp/run_x265.sh "bus ultrafast CRF 28"     $X265 --preset ultrafast --crf 28 --ssim --psnr --frames 150 -o artifacts/bus_ultrafast_crf28.hevc     testdata/xiph/bus_cif.y4m   || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "bus medium CRF 22"        $X265 --preset medium   --crf 22 --ssim --psnr --frames 150 -o artifacts/bus_medium_crf22.hevc         testdata/xiph/bus_cif.y4m   || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "bus slow ABR 1000k"       $X265 --preset slow     --bitrate 1000 --vbv-maxrate 1500 --vbv-bufsize 2000 -F4 --ssim --psnr --frames 150 -o artifacts/bus_slow_abr1000k.hevc testdata/xiph/bus_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "bus veryslow tune grain"  $X265 --preset veryslow --tune grain --crf 20 --ssim --psnr --frames 150 -o artifacts/bus_veryslow_grain.hevc testdata/xiph/bus_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "akiyo medium CRF 22"      $X265 --preset medium   --crf 22 --ssim --psnr --frames 300 -o artifacts/akiyo_medium_crf22.hevc       testdata/xiph/akiyo_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "akiyo slow VBV 500k CBR"  $X265 --preset slow     --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 --strict-cbr -F4 --ssim --psnr --frames 300 -o artifacts/akiyo_slow_vbv500k.hevc testdata/xiph/akiyo_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "akiyo veryslow CRF 18"    $X265 --preset veryslow --crf 18 --ssim --psnr --frames 300 -o artifacts/akiyo_veryslow_crf18.hevc     testdata/xiph/akiyo_cif.y4m || FAIL=$((FAIL+1))
+          echo "=== Validate HEVC bitstreams ==="
           for f in artifacts/*.hevc; do
             if ffprobe -v error -show_entries stream=codec_name "$f" 2>&1 | grep -q hevc; then
               echo "PASS: $f is valid HEVC"
@@ -1272,265 +1653,1191 @@ jobs:
               echo "FAIL: $f is NOT valid HEVC"; FAIL=$((FAIL+1))
             fi
           done
-          echo ""
-          echo "==================== ENCODING SUMMARY ===================="
-          cat /tmp/summary.log 2>/dev/null || true
-          echo "=========================================================="
+          rm -rf artifacts
           echo "=== Video & Validation Results FAIL=$FAIL ==="
-          mkdir -p summaries && cp /tmp/summary.log summaries/video-and-validation.log 2>/dev/null || true
+          test $FAIL -eq 0
+
+      # ── Threading & Parallelism ─────────────────────────────────────────────
+      - name: Test - Threading & Parallelism
+        if: matrix.category == 'threading'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          echo "### Threading & Parallelism" >> /tmp/summary.log
+          /tmp/run_x265.sh "WPP enabled"            $X265 --preset medium --wpp    --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "WPP disabled"           $X265 --preset medium --no-wpp --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          for ft in 1 2 4; do
+            /tmp/run_x265.sh "Frame threads $ft"    $X265 --preset medium --frame-threads $ft   --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for ls in 0 2 4; do
+            /tmp/run_x265.sh "Lookahead slices $ls" $X265 --preset medium --lookahead-slices $ls --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          /tmp/run_x265.sh "Pools=none"             $X265 --preset ultrafast --pools none --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "=== Threading Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      # ── 10-bit & 12-bit Encoding ────────────────────────────────────────────
+      - name: Test - 10-bit & 12-bit Encoding
+        if: matrix.category == 'hbd'
+        run: |
+          X265_10=$(pwd)/dist/10bit/x265
+          X265_12=$(pwd)/dist/12bit/x265
+          FAIL=0
+          echo "### 10-bit Encoding" >> /tmp/summary.log
+          /tmp/run_x265.sh "10-bit ultrafast CRF"  $X265_10 --preset ultrafast --crf 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit medium CRF"     $X265_10 --preset medium   --crf 22 --ssim --psnr --input-res 832x480 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit slow ABR + VBV" $X265_10 --preset slow     --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit veryslow CRF"   $X265_10 --preset veryslow --crf 18 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit lossless"       $X265_10 --preset ultrafast --lossless --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit CQP"            $X265_10 --preset medium   --qp 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit 2-pass pass1"   $X265_10 --preset medium   --bitrate 500 --pass 1 -F4 --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /dev/null testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "10-bit 2-pass pass2"   $X265_10 --preset medium   --bitrate 500 --pass 2 -F4 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
+          /tmp/run_x265.sh "10-bit tune grain"     $X265_10 --preset medium   --tune grain --crf 22 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "" >> /tmp/summary.log
+          echo "### 12-bit Encoding" >> /tmp/summary.log
+          /tmp/run_x265.sh "12-bit ultrafast CRF"  $X265_12 --preset ultrafast --crf 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit medium CRF"     $X265_12 --preset medium   --crf 22 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit slow CRF"       $X265_12 --preset slow     --crf 20 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit lossless"       $X265_12 --preset ultrafast --lossless --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit ABR + VBV"      $X265_12 --preset medium   --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 -F4 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "=== 10-bit/12-bit Results FAIL=$FAIL ==="
           test $FAIL -eq 0
 
       - name: Write step summary
         if: always()
         run: |
           {
-            echo "## Real-World Video & Bitstream Validation"
+            echo "## Linux – ${{ matrix.category }}"
             echo ""
-            echo "| Test | Frames | FPS | Bitrate (kb/s) | Avg QP |"
-            echo "|------|-------:|----:|---------------:|-------:|"
-            if [ -f /tmp/summary.log ] && grep -qv '^[[:space:]]*$' /tmp/summary.log 2>/dev/null; then
+            if [ ! -f /tmp/summary.log ] || ! grep -qv '^[[:space:]]*$' /tmp/summary.log 2>/dev/null; then
+              echo "_No data collected._"
+            else
+              current_section=""
               while IFS= read -r line; do
+                if [[ "$line" == "###"* ]]; then
+                  current_section="$line"
+                  echo ""
+                  echo "$line"
+                  echo ""
+                  echo "| Test | Frames | FPS | Bitrate (kb/s) | Avg QP |"
+                  echo "|------|-------:|----:|---------------:|-------:|"
+                  continue
+                fi
                 [ -z "${line//[[:space:]]/}" ] && continue
-                label=$(echo "$line" | sed 's/^ *//' | cut -d'|' -f1 | sed 's/ *$//')
-                rest=$(echo "$line" | cut -d'|' -f2-)
-                frames=$(echo "$rest" | grep -oP 'encoded \K\d+' || true)
-                fps=$(echo "$rest" | grep -oP '\(\K[\d.]+(?= fps\))' || true)
-                bitrate=$(echo "$rest" | grep -oP '[\d.]+(?= kb/s)' || true)
-                qp=$(echo "$rest" | grep -oP 'Avg QP:\K[\d.]+' || true)
+                label=$(echo "$line" | cut -d'|' -f1 | sed 's/^ *//;s/ *$//')
+                rest=$(echo "$line"  | cut -d'|' -f2-)
+                frames=$(echo "$rest"  | grep -oE 'encoded [0-9]+'        | grep -oE '[0-9]+$' || true)
+                fps=$(echo "$rest"     | perl -ne 'print $1 if /\(([\d.]+) fps\)/' || true)
+                bitrate=$(echo "$rest" | perl -ne 'print $1 if /([\d.]+) kb\/s/'   || true)
+                qp=$(echo "$rest"      | perl -ne 'print $1 if /Avg QP:([\d.]+)/'  || true)
                 echo "| \`${label:-?}\` | ${frames:--} | ${fps:--} | ${bitrate:--} | ${qp:--} |"
               done < /tmp/summary.log
-            else
-              echo "| _no data_ | | | | |"
             fi
-            echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload HEVC artifacts
+      - name: Prepare summary artifact
         if: always() && github.event_name != 'pull_request_target'
-        uses: actions/upload-artifact@v7
-        with:
-          name: hevc-realworld
-          path: artifacts/*.hevc
-          retention-days: 3
+        run: |
+          mkdir -p summaries
+          cp /tmp/summary.log summaries/linux-${{ matrix.category }}.log 2>/dev/null || touch summaries/linux-${{ matrix.category }}.log
 
       - name: Upload summaries
         if: always() && github.event_name != 'pull_request_target'
         uses: actions/upload-artifact@v7
         with:
-          name: summaries-video-and-validation
+          name: summaries-linux-${{ matrix.category }}
           path: summaries/*.log
           retention-days: 3
 
+  # ───────────────────────────────────────────────────────────────────────────
 
-  test-threading:
-    name: "Test Threading & Parallelism"
-    runs-on: ubuntu-22.04
-    timeout-minutes: 20
-    needs: build-8bit
+  test-macos:
+    name: "Test macOS (${{ matrix.category }})"
+    runs-on: macos-latest
+    timeout-minutes: 60
+    needs: build-macos
+    strategy:
+      fail-fast: false
+      matrix:
+        category: [presets-tune, rate-control, encoding-features, analysis-reuse, real-world, threading, hbd]
     steps:
       - name: Download 8-bit binary
         uses: actions/download-artifact@v8
         with:
-          name: x265-8bit
-          path: dist
+          name: x265-macos-8bit
+          path: dist/8bit
 
-      - name: Cache apt packages
-        uses: actions/cache@v5
-        with:
-          path: /home/runner/apt-archives
-          key: apt-test-${{ runner.os }}-v2
-          restore-keys: apt-test-${{ runner.os }}-v2
-      - name: Pre-populate apt cache
-        run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
-
-      - name: Install runtime dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libnuma1 ffmpeg
-
-      - name: Prepare apt cache
-        if: always()
-        run: |
-          mkdir -p /home/runner/apt-archives
-          cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
-
-      - name: Run tests
-        run: |
-          chmod +x dist/x265
-          X265=$(pwd)/dist/x265
-          mkdir -p testdata
-          ffmpeg -y -f lavfi -i testsrc=duration=2:size=832x480:rate=30 -pix_fmt yuv420p testdata/test_420_832x480.yuv
-          FAIL=0
-          run_x265() {
-            local label="$1"; shift
-            echo "=== $label ==="
-            "$@" 2>&1 | tee /tmp/x265_last.log
-            local rc=${PIPESTATUS[0]}
-            local summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
-            [ -n "$summary" ] && printf "  %-45s | %s\n" "$label" "$summary" >> /tmp/summary.log
-            return $rc
-          }
-          echo "" > /tmp/summary.log
-          run_x265 "WPP enabled"            $X265 --preset medium --wpp    --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "WPP disabled"           $X265 --preset medium --no-wpp --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          for ft in 1 2 4; do
-            run_x265 "Frame threads $ft"    $X265 --preset medium --frame-threads $ft   --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          done
-          for ls in 0 2 4; do
-            run_x265 "Lookahead slices $ls" $X265 --preset medium --lookahead-slices $ls --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          done
-          run_x265 "Pools=none"             $X265 --preset ultrafast --pools none --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_420_832x480.yuv || FAIL=$((FAIL+1))
-          rm -f /tmp/out.hevc
-          echo ""
-          echo "==================== ENCODING SUMMARY ===================="
-          cat /tmp/summary.log 2>/dev/null || true
-          echo "=========================================================="
-          echo "=== Threading Results FAIL=$FAIL ==="
-          mkdir -p summaries && cp /tmp/summary.log summaries/threading.log 2>/dev/null || true
-          test $FAIL -eq 0
-
-      - name: Write step summary
-        if: always()
-        run: |
-          {
-            echo "## Threading & Parallelism"
-            echo ""
-            echo "| Test | Frames | FPS | Bitrate (kb/s) | Avg QP |"
-            echo "|------|-------:|----:|---------------:|-------:|"
-            if [ -f /tmp/summary.log ] && grep -qv '^[[:space:]]*$' /tmp/summary.log 2>/dev/null; then
-              while IFS= read -r line; do
-                [ -z "${line//[[:space:]]/}" ] && continue
-                label=$(echo "$line" | sed 's/^ *//' | cut -d'|' -f1 | sed 's/ *$//')
-                rest=$(echo "$line" | cut -d'|' -f2-)
-                frames=$(echo "$rest" | grep -oP 'encoded \K\d+' || true)
-                fps=$(echo "$rest" | grep -oP '\(\K[\d.]+(?= fps\))' || true)
-                bitrate=$(echo "$rest" | grep -oP '[\d.]+(?= kb/s)' || true)
-                qp=$(echo "$rest" | grep -oP 'Avg QP:\K[\d.]+' || true)
-                echo "| \`${label:-?}\` | ${frames:--} | ${fps:--} | ${bitrate:--} | ${qp:--} |"
-              done < /tmp/summary.log
-            else
-              echo "| _no data_ | | | | |"
-            fi
-            echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload summaries
-        if: always() && github.event_name != 'pull_request_target'
-        uses: actions/upload-artifact@v7
-        with:
-          name: summaries-threading
-          path: summaries/*.log
-          retention-days: 3
-
-  test-10bit-12bit-encoding:
-    name: "Test 10-bit & 12-bit Encoding"
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    needs: [build-10bit, build-12bit]
-    steps:
       - name: Download 10-bit binary
         uses: actions/download-artifact@v8
         with:
-          name: x265-10bit
+          name: x265-macos-10bit
           path: dist/10bit
 
       - name: Download 12-bit binary
         uses: actions/download-artifact@v8
         with:
-          name: x265-12bit
+          name: x265-macos-12bit
+          path: dist/12bit
+
+      - name: Install runtime dependencies
+        run: |
+          brew untap aws/tap || true
+          brew install ffmpeg
+
+      - name: Make binaries executable
+        run: |
+          chmod +x dist/8bit/x265 dist/10bit/x265 dist/12bit/x265
+
+      - name: Generate test data
+        run: |
+          mkdir -p testdata
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv420p     testdata/test_8bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=832x480:rate=30  -pix_fmt yuv420p     testdata/test_8bit_832x480.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv422p     testdata/test_422_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv444p     testdata/test_444_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv420p10le testdata/test_10bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=832x480:rate=30  -pix_fmt yuv420p10le testdata/test_10bit_832x480.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv420p12le testdata/test_12bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=1920x1080:rate=25 -pix_fmt yuv420p    testdata/test_8bit_1080p.yuv
+
+      - name: Cache xiph.org test videos
+        id: cache-videos
+        uses: actions/cache@v5
+        with:
+          path: testdata/xiph
+          key: xiph-test-videos-v1
+      - name: Download xiph test videos (cache miss only)
+        if: steps.cache-videos.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p testdata/xiph
+          wget -q --tries=3 --timeout=60 -O testdata/xiph/bus_cif.y4m   https://media.xiph.org/video/derf/y4m/bus_cif.y4m
+          wget -q --tries=3 --timeout=60 -O testdata/xiph/akiyo_cif.y4m https://media.xiph.org/video/derf/y4m/akiyo_cif.y4m
+
+      - name: Define helper
+        run: |
+          cat > /tmp/run_x265.sh << 'HELPER'
+          #!/usr/bin/env bash
+          label="$1"; shift
+          echo "=== $label ==="
+          "$@" 2>&1 | tee /tmp/x265_last.log
+          rc=${PIPESTATUS[0]}
+          summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
+          [ -n "$summary" ] && printf "%-50s | %s\n" "$label" "$summary" >> /tmp/summary.log
+          exit $rc
+          HELPER
+          chmod +x /tmp/run_x265.sh
+
+      - name: Test - CLI Presets & Tune Modes
+        if: matrix.category == 'presets-tune'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          PASS=0; FAIL=0; TOTAL=0
+          echo "### Presets" >> /tmp/summary.log
+          for preset in ultrafast superfast veryfast faster fast medium slow slower veryslow; do
+            TOTAL=$((TOTAL + 1))
+            if /tmp/run_x265.sh "Preset $preset" $X265 --preset $preset --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv; then
+              PASS=$((PASS + 1))
+            else
+              FAIL=$((FAIL + 1))
+            fi
+            rm -f /tmp/out.hevc
+          done
+          echo "" >> /tmp/summary.log
+          echo "### Tune Modes" >> /tmp/summary.log
+          for tune in psnr ssim grain fastdecode zerolatency; do
+            TOTAL=$((TOTAL + 1))
+            if /tmp/run_x265.sh "Tune $tune" $X265 --preset medium --tune $tune --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv; then
+              PASS=$((PASS + 1))
+            else
+              FAIL=$((FAIL + 1))
+            fi
+            rm -f /tmp/out.hevc
+          done
+          echo "=== Preset/Tune Results $PASS/$TOTAL passed, $FAIL failed ==="
+          test $FAIL -eq 0
+
+      - name: Test - Rate Control Modes
+        if: matrix.category == 'rate-control'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          echo "### Rate Control" >> /tmp/summary.log
+          /tmp/run_x265.sh "CRF Mode"                   $X265 --preset medium --crf 22 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "CQP Mode"                   $X265 --preset medium --qp 28  --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "ABR Mode"                   $X265 --preset medium --bitrate 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "VBV Constrained"            $X265 --preset medium --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Strict CBR"                 $X265 --preset medium --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 --strict-cbr -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "CRF + VBV"                  $X265 --preset medium --crf 22 --vbv-maxrate 2000 --vbv-bufsize 3000 --crf-max 32 --crf-min 18 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "2-pass p1"                  $X265 --preset medium --bitrate 1000 --pass 1 -F4 --input-res 832x480 --fps 30 --frames 60 -o /dev/null testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "2-pass p2"                  $X265 --preset medium --bitrate 1000 --pass 2 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
+          /tmp/run_x265.sh "Multi-pass Opt Analysis p1" $X265 --preset medium --bitrate 1000 --pass 1 --multi-pass-opt-analysis --input-res 832x480 --fps 30 --frames 60 -o /dev/null testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "Multi-pass Opt Analysis p2" $X265 --preset medium --bitrate 1000 --pass 2 --multi-pass-opt-analysis --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
+          echo "=== Rate Control Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - Encoding Features
+        if: matrix.category == 'encoding-features'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          echo "### Encoding Features" >> /tmp/summary.log
+          /tmp/run_x265.sh "Lossless"           $X265 --preset ultrafast --lossless --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "CU Lossless"        $X265 --preset medium --crf 22 --cu-lossless --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          for ctu in 16 32 64; do
+            /tmp/run_x265.sh "CTU $ctu"         $X265 --preset medium --ctu $ctu --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for aqmode in 0 3; do
+            /tmp/run_x265.sh "AQ Mode $aqmode"  $X265 --preset medium --aq-mode $aqmode --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for me in hex umh full; do
+            /tmp/run_x265.sh "ME $me"           $X265 --preset medium --me $me --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          /tmp/run_x265.sh "SAO + Deblock"      $X265 --preset medium --sao --deblock 2:2 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "No SAO/Deblock"     $X265 --preset medium --no-sao --no-deblock --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Limit SAO"          $X265 --preset medium --limit-sao --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Weighted P+B"       $X265 --preset medium --weightp --weightb --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "B-frames 0"         $X265 --preset medium --bframes 0  --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "B-frames 16"        $X265 --preset medium --bframes 16 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Infinite Keyint"    $X265 --preset medium --keyint -1 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Short Keyint"       $X265 --preset medium --keyint 10 --min-keyint 5 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Closed GOP"         $X265 --preset medium --no-open-gop --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Constrained Intra"  $X265 --preset medium --constrained-intra --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          for rd in 2 5; do
+            /tmp/run_x265.sh "RD Level $rd"     $X265 --preset medium --rd $rd --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for rdoq in 0 2; do
+            /tmp/run_x265.sh "RDOQ Level $rdoq" $X265 --preset medium --rdoq-level $rdoq --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          /tmp/run_x265.sh "Scaling List"       $X265 --preset medium --scaling-list default --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Noise Reduction"    $X265 --preset medium --nr-intra 500 --nr-inter 300 -F4 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Psy-RD + Psy-RDOQ" $X265 --preset medium --psy-rd 1.5 --psy-rdoq 1.0 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "No Psy"             $X265 --preset medium --no-psy-rd --no-psy-rdoq --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Multiple Slices"    $X265 --preset medium --slices 4 --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Temporal Layers"    $X265 --preset medium --temporal-layers 3 --b-adapt 0 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "HEVC-AQ"            $X265 --preset medium --hevc-aq --no-cutree --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "HME"                $X265 --preset medium --hme --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Lowpass DCT"        $X265 --preset medium --lowpass-dct --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Streaming Flags"    $X265 --preset medium --hrd --aud --repeat-headers --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "422 Input"          $X265 --preset medium --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_422_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "444 Input"          $X265 --preset medium --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_444_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Segment Encoding"   $X265 --preset ultrafast --no-open-gop --chunk-start 10 --chunk-end 50 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "" >> /tmp/summary.log
+          echo "### Quality Metrics" >> /tmp/summary.log
+          /tmp/run_x265.sh "SSIM Metric"        $X265 --preset medium --ssim        --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1))
+          grep -qi "ssim" /tmp/x265_last.log || { echo "FAIL: ssim not reported"; FAIL=$((FAIL+1)); }
+          rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "PSNR Metric"        $X265 --preset medium --psnr        --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1))
+          grep -qi "psnr" /tmp/x265_last.log || { echo "FAIL: psnr not reported"; FAIL=$((FAIL+1)); }
+          rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "SSIM + PSNR"        $X265 --preset medium --ssim --psnr --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Hash (MD5)"         $X265 --preset medium --hash 1      --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Recon Output"       $X265 --preset medium               --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc -r /tmp/recon.yuv testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1))
+          test -f /tmp/recon.yuv && echo "Recon file created OK" || { echo "FAIL: recon file missing"; FAIL=$((FAIL+1)); }
+          rm -f /tmp/out.hevc /tmp/recon.yuv
+          echo "" >> /tmp/summary.log
+          echo "### MCSTF, SBRC & Interlace" >> /tmp/summary.log
+          /tmp/run_x265.sh "MCSTF slower"          $X265 --preset slower    --crf 24 --mcstf --bframes 5 --frame-threads 1 --no-cutree --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "MCSTF medium"          $X265 --preset medium    --crf 26 --mcstf --bframes 5 --frame-threads 1 --tskip-fast --constrained-intra --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "MCSTF slow"            $X265 --preset slow      --crf 24 --mcstf --bframes 5 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "SBRC slow"             $X265 --preset slow      --crf 26 --sbrc --no-open-gop --keyint 60 --min-keyint 60 --vbv-bufsize 6000 --vbv-maxrate 5000 --temporal-layers 4 --b-adapt 0 --no-cutree --input-res 1920x1080 --fps 25 --frames 50 -o /tmp/out.hevc testdata/test_8bit_1080p.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "SBRC superfast"        $X265 --preset superfast --crf 22 --sbrc --no-open-gop --vbv-maxrate 9000 --vbv-bufsize 7500 --keyint 100 --min-keyint 100 --input-res 1920x1080 --fps 25 --frames 50 -o /tmp/out.hevc testdata/test_8bit_1080p.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Interlace TFF"         $X265 --preset faster    --interlace tff --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Interlace BFF"         $X265 --preset fast      --interlace bff --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Interlace BFF+weightb" $X265 --preset fast      --interlace bff --weightb --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "=== Encoding Features Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - Analysis Save/Load
+        if: matrix.category == 'analysis-reuse'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          echo "### Analysis Save/Load" >> /tmp/summary.log
+          /tmp/run_x265.sh "Analysis Save (level 2)"  $X265 --preset medium --analysis-save x265_analysis.dat    --analysis-save-reuse-level 2  --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Analysis Load (level 2)"  $X265 --preset medium --analysis-load x265_analysis.dat    --analysis-load-reuse-level 2  --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Analysis Save (level 10)" $X265 --preset slow   --analysis-save x265_analysis_10.dat --analysis-save-reuse-level 10 --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Analysis Load (level 10)" $X265 --preset slow   --analysis-load x265_analysis_10.dat --analysis-load-reuse-level 10 --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_analysis*.dat
+          echo "=== Analysis Save/Load Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - Real-World Video & Bitstream Validation
+        if: matrix.category == 'real-world'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          mkdir -p artifacts
+          echo "### Bitstream Validation" >> /tmp/summary.log
+          validate_encode() {
+            local label="$1"; shift
+            echo "=== $label ==="
+            local outfile="/tmp/validate_${RANDOM}.hevc"
+            $X265 "$@" -o "$outfile" testdata/test_8bit_416x240.yuv 2>&1 | tee /tmp/x265_last.log
+            local rc=${PIPESTATUS[0]}
+            local summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
+            [ -n "$summary" ] && printf "%-50s | %s\n" "$label" "$summary" >> /tmp/summary.log
+            if [ $rc -eq 0 ]; then
+              if ffprobe -v error -show_entries stream=codec_name "$outfile" 2>&1 | grep -q hevc; then
+                echo "PASS: $label (encode + probe)"
+                if ffmpeg -y -i "$outfile" -frames:v 5 -f rawvideo /dev/null 2>&1; then
+                  echo "PASS: $label (decode)"
+                else
+                  echo "FAIL: $label (decode failed)"; FAIL=$((FAIL+1))
+                fi
+              else
+                echo "FAIL: $label (not valid HEVC)"; FAIL=$((FAIL+1))
+              fi
+            else
+              echo "FAIL: $label (encode failed)"; FAIL=$((FAIL+1))
+            fi
+            rm -f "$outfile"
+          }
+          validate_encode "CRF ultrafast" --preset ultrafast --crf 28              --input-res 416x240 --fps 30 --frames 30
+          validate_encode "CRF medium"    --preset medium   --crf 22              --input-res 416x240 --fps 30 --frames 30
+          validate_encode "CRF veryslow"  --preset veryslow --crf 18              --input-res 416x240 --fps 30 --frames 30
+          validate_encode "ABR + VBV"     --preset medium   --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 -F4 --input-res 416x240 --fps 30 --frames 30
+          validate_encode "Lossless"      --preset ultrafast --lossless            --input-res 416x240 --fps 30 --frames 30
+          validate_encode "HRD compliant" --preset medium   --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 --hrd --aud --repeat-headers -F4 --input-res 416x240 --fps 30 --frames 30
+          validate_encode "Closed GOP"    --preset medium   --no-open-gop --keyint 10 --crf 28 --input-res 416x240 --fps 30 --frames 30
+          validate_encode "Zero-latency"  --preset medium   --tune zerolatency --crf 28 --input-res 416x240 --fps 30 --frames 30
+          echo "" >> /tmp/summary.log
+          echo "### Real-World Video (Y4M)" >> /tmp/summary.log
+          /tmp/run_x265.sh "bus ultrafast CRF 28"    $X265 --preset ultrafast --crf 28 --ssim --psnr --frames 150 -o artifacts/bus_ultrafast_crf28.hevc    testdata/xiph/bus_cif.y4m   || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "bus medium CRF 22"       $X265 --preset medium   --crf 22 --ssim --psnr --frames 150 -o artifacts/bus_medium_crf22.hevc        testdata/xiph/bus_cif.y4m   || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "bus slow ABR 1000k"      $X265 --preset slow     --bitrate 1000 --vbv-maxrate 1500 --vbv-bufsize 2000 -F4 --ssim --psnr --frames 150 -o artifacts/bus_slow_abr1000k.hevc testdata/xiph/bus_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "bus veryslow tune grain" $X265 --preset veryslow --tune grain --crf 20 --ssim --psnr --frames 150 -o artifacts/bus_veryslow_grain.hevc testdata/xiph/bus_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "akiyo medium CRF 22"     $X265 --preset medium   --crf 22 --ssim --psnr --frames 300 -o artifacts/akiyo_medium_crf22.hevc      testdata/xiph/akiyo_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "akiyo slow VBV 500k CBR" $X265 --preset slow     --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 --strict-cbr -F4 --ssim --psnr --frames 300 -o artifacts/akiyo_slow_vbv500k.hevc testdata/xiph/akiyo_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "akiyo veryslow CRF 18"   $X265 --preset veryslow --crf 18 --ssim --psnr --frames 300 -o artifacts/akiyo_veryslow_crf18.hevc    testdata/xiph/akiyo_cif.y4m || FAIL=$((FAIL+1))
+          echo "=== Validate HEVC bitstreams ==="
+          for f in artifacts/*.hevc; do
+            if ffprobe -v error -show_entries stream=codec_name "$f" 2>&1 | grep -q hevc; then
+              echo "PASS: $f is valid HEVC"
+            else
+              echo "FAIL: $f is NOT valid HEVC"; FAIL=$((FAIL+1))
+            fi
+          done
+          rm -rf artifacts
+          echo "=== Video & Validation Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - Threading & Parallelism
+        if: matrix.category == 'threading'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          echo "### Threading & Parallelism" >> /tmp/summary.log
+          /tmp/run_x265.sh "WPP enabled"            $X265 --preset medium --wpp    --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "WPP disabled"           $X265 --preset medium --no-wpp --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          for ft in 1 2 4; do
+            /tmp/run_x265.sh "Frame threads $ft"    $X265 --preset medium --frame-threads $ft   --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for ls in 0 2 4; do
+            /tmp/run_x265.sh "Lookahead slices $ls" $X265 --preset medium --lookahead-slices $ls --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          /tmp/run_x265.sh "Pools=none"             $X265 --preset ultrafast --pools none --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "=== Threading Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - 10-bit & 12-bit Encoding
+        if: matrix.category == 'hbd'
+        run: |
+          X265_10=$(pwd)/dist/10bit/x265
+          X265_12=$(pwd)/dist/12bit/x265
+          FAIL=0
+          echo "### 10-bit Encoding" >> /tmp/summary.log
+          /tmp/run_x265.sh "10-bit ultrafast CRF"  $X265_10 --preset ultrafast --crf 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit medium CRF"     $X265_10 --preset medium   --crf 22 --ssim --psnr --input-res 832x480 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit slow ABR + VBV" $X265_10 --preset slow     --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit veryslow CRF"   $X265_10 --preset veryslow --crf 18 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit lossless"       $X265_10 --preset ultrafast --lossless --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit CQP"            $X265_10 --preset medium   --qp 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit 2-pass pass1"   $X265_10 --preset medium   --bitrate 500 --pass 1 -F4 --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /dev/null testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "10-bit 2-pass pass2"   $X265_10 --preset medium   --bitrate 500 --pass 2 -F4 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
+          /tmp/run_x265.sh "10-bit tune grain"     $X265_10 --preset medium   --tune grain --crf 22 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "" >> /tmp/summary.log
+          echo "### 12-bit Encoding" >> /tmp/summary.log
+          /tmp/run_x265.sh "12-bit ultrafast CRF"  $X265_12 --preset ultrafast --crf 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit medium CRF"     $X265_12 --preset medium   --crf 22 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit slow CRF"       $X265_12 --preset slow     --crf 20 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit lossless"       $X265_12 --preset ultrafast --lossless --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit ABR + VBV"      $X265_12 --preset medium   --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 -F4 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "=== 10-bit/12-bit Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Write step summary
+        if: always()
+        run: |
+          {
+            echo "## macOS – ${{ matrix.category }}"
+            echo ""
+            if [ ! -f /tmp/summary.log ] || ! grep -qv '^[[:space:]]*$' /tmp/summary.log 2>/dev/null; then
+              echo "_No data collected._"
+            else
+              while IFS= read -r line; do
+                if [[ "$line" == "###"* ]]; then
+                  echo ""
+                  echo "$line"
+                  echo ""
+                  echo "| Test | Frames | FPS | Bitrate (kb/s) | Avg QP |"
+                  echo "|------|-------:|----:|---------------:|-------:|"
+                  continue
+                fi
+                [ -z "${line//[[:space:]]/}" ] && continue
+                label=$(echo "$line" | cut -d'|' -f1 | sed 's/^ *//;s/ *$//')
+                rest=$(echo "$line"  | cut -d'|' -f2-)
+                frames=$(echo "$rest"  | grep -oE 'encoded [0-9]+'        | grep -oE '[0-9]+$' || true)
+                fps=$(echo "$rest"     | perl -ne 'print $1 if /\(([\d.]+) fps\)/' || true)
+                bitrate=$(echo "$rest" | perl -ne 'print $1 if /([\d.]+) kb\/s/'   || true)
+                qp=$(echo "$rest"      | perl -ne 'print $1 if /Avg QP:([\d.]+)/'  || true)
+                echo "| \`${label:-?}\` | ${frames:--} | ${fps:--} | ${bitrate:--} | ${qp:--} |"
+              done < /tmp/summary.log
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prepare summary artifact
+        if: always() && github.event_name != 'pull_request_target'
+        run: |
+          mkdir -p summaries
+          cp /tmp/summary.log summaries/macos-${{ matrix.category }}.log 2>/dev/null || touch summaries/macos-${{ matrix.category }}.log
+
+      - name: Upload summaries
+        if: always() && github.event_name != 'pull_request_target'
+        uses: actions/upload-artifact@v7
+        with:
+          name: summaries-macos-${{ matrix.category }}
+          path: summaries/*.log
+          retention-days: 3
+
+  # ───────────────────────────────────────────────────────────────────────────
+
+  test-aarch64:
+    name: "Test AArch64 (${{ matrix.category }}, QEMU)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    needs: build-aarch64
+    strategy:
+      fail-fast: false
+      matrix:
+        category: [presets-tune, rate-control, encoding-features, analysis-reuse, real-world, threading, hbd]
+    steps:
+      - name: Download 8-bit binary
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-aarch64-8bit
+          path: dist/8bit
+
+      - name: Download 10-bit binary
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-aarch64-10bit
+          path: dist/10bit
+
+      - name: Download 12-bit binary
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-aarch64-12bit
           path: dist/12bit
 
       - name: Cache apt packages
         uses: actions/cache@v5
         with:
           path: /home/runner/apt-archives
-          key: apt-test-${{ runner.os }}-v2
-          restore-keys: apt-test-${{ runner.os }}-v2
+          key: apt-test-aarch64-v2
+          restore-keys: apt-test-aarch64-v2
       - name: Pre-populate apt cache
         run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
 
-      - name: Install runtime dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libnuma1 ffmpeg
+      - name: Install AArch64 runtime and test tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq \
+            qemu-user-static \
+            libc6-arm64-cross \
+            libstdc++6-arm64-cross \
+            ffmpeg \
+            wget
 
-      - name: Prepare apt cache
+      - name: Save apt cache
         if: always()
         run: |
           mkdir -p /home/runner/apt-archives
           cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
 
-      - name: Run tests
+      - name: Make binaries executable
         run: |
-          chmod +x dist/10bit/x265 dist/12bit/x265
-          X265_10=$(pwd)/dist/10bit/x265
-          X265_12=$(pwd)/dist/12bit/x265
+          chmod +x dist/8bit/x265 dist/10bit/x265 dist/12bit/x265
+
+      - name: Generate test data
+        run: |
           mkdir -p testdata
-          ffmpeg -y -f lavfi -i testsrc=duration=2:size=832x480:rate=30 -pix_fmt yuv420p10le testdata/test_10bit_832x480.yuv
-          ffmpeg -y -f lavfi -i testsrc=duration=2:size=416x240:rate=30 -pix_fmt yuv420p10le testdata/test_10bit_416x240.yuv
-          ffmpeg -y -f lavfi -i testsrc=duration=2:size=416x240:rate=30 -pix_fmt yuv420p12le testdata/test_12bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv420p     testdata/test_8bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=832x480:rate=30  -pix_fmt yuv420p     testdata/test_8bit_832x480.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv422p     testdata/test_422_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv444p     testdata/test_444_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv420p10le testdata/test_10bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=832x480:rate=30  -pix_fmt yuv420p10le testdata/test_10bit_832x480.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv420p12le testdata/test_12bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=1920x1080:rate=25 -pix_fmt yuv420p    testdata/test_8bit_1080p.yuv
+
+      - name: Cache xiph.org test videos
+        id: cache-videos
+        uses: actions/cache@v5
+        with:
+          path: testdata/xiph
+          key: xiph-test-videos-v1
+      - name: Download xiph test videos (cache miss only)
+        if: steps.cache-videos.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p testdata/xiph
+          wget -q --tries=3 --timeout=60 -O testdata/xiph/bus_cif.y4m   https://media.xiph.org/video/derf/y4m/bus_cif.y4m
+          wget -q --tries=3 --timeout=60 -O testdata/xiph/akiyo_cif.y4m https://media.xiph.org/video/derf/y4m/akiyo_cif.y4m
+
+      - name: Define helper
+        run: |
+          cat > /tmp/run_x265.sh << 'HELPER'
+          #!/usr/bin/env bash
+          label="$1"; shift
+          echo "=== $label ==="
+          export QEMU_LD_PREFIX=/usr/aarch64-linux-gnu
+          bin="$1"; shift
+          qemu-aarch64-static "$bin" "$@" 2>&1 | tee /tmp/x265_last.log
+          rc=${PIPESTATUS[0]}
+          summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
+          [ -n "$summary" ] && printf "%-50s | %s\n" "$label" "$summary" >> /tmp/summary.log
+          exit $rc
+          HELPER
+          chmod +x /tmp/run_x265.sh
+
+      - name: Test - CLI Presets & Tune Modes
+        if: matrix.category == 'presets-tune'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          PASS=0; FAIL=0; TOTAL=0
+          echo "### Presets" >> /tmp/summary.log
+          for preset in ultrafast superfast veryfast faster fast medium slow slower veryslow; do
+            TOTAL=$((TOTAL + 1))
+            if /tmp/run_x265.sh "Preset $preset" $X265 --preset $preset --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv; then
+              PASS=$((PASS + 1))
+            else
+              FAIL=$((FAIL + 1))
+            fi
+            rm -f /tmp/out.hevc
+          done
+          echo "" >> /tmp/summary.log
+          echo "### Tune Modes" >> /tmp/summary.log
+          for tune in psnr ssim grain fastdecode zerolatency; do
+            TOTAL=$((TOTAL + 1))
+            if /tmp/run_x265.sh "Tune $tune" $X265 --preset medium --tune $tune --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv; then
+              PASS=$((PASS + 1))
+            else
+              FAIL=$((FAIL + 1))
+            fi
+            rm -f /tmp/out.hevc
+          done
+          echo "=== Preset/Tune Results $PASS/$TOTAL passed, $FAIL failed ==="
+          test $FAIL -eq 0
+
+      - name: Test - Rate Control Modes
+        if: matrix.category == 'rate-control'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
           FAIL=0
-          run_x265() {
+          echo "### Rate Control" >> /tmp/summary.log
+          /tmp/run_x265.sh "CRF Mode"                   $X265 --preset medium --crf 22 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "CQP Mode"                   $X265 --preset medium --qp 28  --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "ABR Mode"                   $X265 --preset medium --bitrate 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "VBV Constrained"            $X265 --preset medium --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Strict CBR"                 $X265 --preset medium --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 --strict-cbr -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "CRF + VBV"                  $X265 --preset medium --crf 22 --vbv-maxrate 2000 --vbv-bufsize 3000 --crf-max 32 --crf-min 18 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "2-pass p1"                  $X265 --preset medium --bitrate 1000 --pass 1 -F4 --input-res 832x480 --fps 30 --frames 60 -o /dev/null testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "2-pass p2"                  $X265 --preset medium --bitrate 1000 --pass 2 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
+          /tmp/run_x265.sh "Multi-pass Opt Analysis p1" $X265 --preset medium --bitrate 1000 --pass 1 --multi-pass-opt-analysis --input-res 832x480 --fps 30 --frames 60 -o /dev/null testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "Multi-pass Opt Analysis p2" $X265 --preset medium --bitrate 1000 --pass 2 --multi-pass-opt-analysis --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
+          echo "=== Rate Control Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - Encoding Features
+        if: matrix.category == 'encoding-features'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          echo "### Encoding Features" >> /tmp/summary.log
+          /tmp/run_x265.sh "Lossless"           $X265 --preset ultrafast --lossless --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "CU Lossless"        $X265 --preset medium --crf 22 --cu-lossless --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          for ctu in 16 32 64; do
+            /tmp/run_x265.sh "CTU $ctu"         $X265 --preset medium --ctu $ctu --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for aqmode in 0 3; do
+            /tmp/run_x265.sh "AQ Mode $aqmode"  $X265 --preset medium --aq-mode $aqmode --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for me in hex umh full; do
+            /tmp/run_x265.sh "ME $me"           $X265 --preset medium --me $me --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          /tmp/run_x265.sh "SAO + Deblock"      $X265 --preset medium --sao --deblock 2:2 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "No SAO/Deblock"     $X265 --preset medium --no-sao --no-deblock --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Limit SAO"          $X265 --preset medium --limit-sao --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Weighted P+B"       $X265 --preset medium --weightp --weightb --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "B-frames 0"         $X265 --preset medium --bframes 0  --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "B-frames 16"        $X265 --preset medium --bframes 16 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Infinite Keyint"    $X265 --preset medium --keyint -1 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Short Keyint"       $X265 --preset medium --keyint 10 --min-keyint 5 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Closed GOP"         $X265 --preset medium --no-open-gop --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Constrained Intra"  $X265 --preset medium --constrained-intra --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          for rd in 2 5; do
+            /tmp/run_x265.sh "RD Level $rd"     $X265 --preset medium --rd $rd --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for rdoq in 0 2; do
+            /tmp/run_x265.sh "RDOQ Level $rdoq" $X265 --preset medium --rdoq-level $rdoq --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          /tmp/run_x265.sh "Scaling List"       $X265 --preset medium --scaling-list default --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Noise Reduction"    $X265 --preset medium --nr-intra 500 --nr-inter 300 -F4 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Psy-RD + Psy-RDOQ" $X265 --preset medium --psy-rd 1.5 --psy-rdoq 1.0 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "No Psy"             $X265 --preset medium --no-psy-rd --no-psy-rdoq --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Multiple Slices"    $X265 --preset medium --slices 4 --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Temporal Layers"    $X265 --preset medium --temporal-layers 3 --b-adapt 0 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "HEVC-AQ"            $X265 --preset medium --hevc-aq --no-cutree --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "HME"                $X265 --preset medium --hme --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Lowpass DCT"        $X265 --preset medium --lowpass-dct --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Streaming Flags"    $X265 --preset medium --hrd --aud --repeat-headers --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "422 Input"          $X265 --preset medium --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_422_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "444 Input"          $X265 --preset medium --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_444_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Segment Encoding"   $X265 --preset ultrafast --no-open-gop --chunk-start 10 --chunk-end 50 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "" >> /tmp/summary.log
+          echo "### Quality Metrics" >> /tmp/summary.log
+          /tmp/run_x265.sh "SSIM Metric" $X265 --preset medium --ssim --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1))
+          grep -qi "ssim" /tmp/x265_last.log || { echo "FAIL: ssim not reported"; FAIL=$((FAIL+1)); }; rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "PSNR Metric" $X265 --preset medium --psnr --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1))
+          grep -qi "psnr" /tmp/x265_last.log || { echo "FAIL: psnr not reported"; FAIL=$((FAIL+1)); }; rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "SSIM + PSNR" $X265 --preset medium --ssim --psnr --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Hash (MD5)"  $X265 --preset medium --hash 1 --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Recon Output" $X265 --preset medium --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc -r /tmp/recon.yuv testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1))
+          test -f /tmp/recon.yuv || { echo "FAIL: recon file missing"; FAIL=$((FAIL+1)); }; rm -f /tmp/out.hevc /tmp/recon.yuv
+          echo "" >> /tmp/summary.log
+          echo "### MCSTF, SBRC & Interlace" >> /tmp/summary.log
+          /tmp/run_x265.sh "MCSTF slower"          $X265 --preset slower    --crf 24 --mcstf --bframes 5 --frame-threads 1 --no-cutree --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "MCSTF medium"          $X265 --preset medium    --crf 26 --mcstf --bframes 5 --frame-threads 1 --tskip-fast --constrained-intra --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "MCSTF slow"            $X265 --preset slow      --crf 24 --mcstf --bframes 5 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "SBRC slow"             $X265 --preset slow      --crf 26 --sbrc --no-open-gop --keyint 60 --min-keyint 60 --vbv-bufsize 6000 --vbv-maxrate 5000 --temporal-layers 4 --b-adapt 0 --no-cutree --input-res 1920x1080 --fps 25 --frames 50 -o /tmp/out.hevc testdata/test_8bit_1080p.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "SBRC superfast"        $X265 --preset superfast --crf 22 --sbrc --no-open-gop --vbv-maxrate 9000 --vbv-bufsize 7500 --keyint 100 --min-keyint 100 --input-res 1920x1080 --fps 25 --frames 50 -o /tmp/out.hevc testdata/test_8bit_1080p.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Interlace TFF"         $X265 --preset faster    --interlace tff --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Interlace BFF"         $X265 --preset fast      --interlace bff --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Interlace BFF+weightb" $X265 --preset fast      --interlace bff --weightb --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "=== Encoding Features Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - Analysis Save/Load
+        if: matrix.category == 'analysis-reuse'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          echo "### Analysis Save/Load" >> /tmp/summary.log
+          /tmp/run_x265.sh "Analysis Save (level 2)"  $X265 --preset medium --analysis-save x265_analysis.dat    --analysis-save-reuse-level 2  --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Analysis Load (level 2)"  $X265 --preset medium --analysis-load x265_analysis.dat    --analysis-load-reuse-level 2  --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Analysis Save (level 10)" $X265 --preset slow   --analysis-save x265_analysis_10.dat --analysis-save-reuse-level 10 --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Analysis Load (level 10)" $X265 --preset slow   --analysis-load x265_analysis_10.dat --analysis-load-reuse-level 10 --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_analysis*.dat
+          echo "=== Analysis Save/Load Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - Real-World Video & Bitstream Validation
+        if: matrix.category == 'real-world'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          mkdir -p artifacts
+          echo "### Bitstream Validation" >> /tmp/summary.log
+          validate_encode() {
             local label="$1"; shift
             echo "=== $label ==="
-            "$@" 2>&1 | tee /tmp/x265_last.log
+            local outfile="/tmp/validate_${RANDOM}.hevc"
+            export QEMU_LD_PREFIX=/usr/aarch64-linux-gnu
+            qemu-aarch64-static "$X265" "$@" -o "$outfile" testdata/test_8bit_416x240.yuv 2>&1 | tee /tmp/x265_last.log
             local rc=${PIPESTATUS[0]}
             local summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
-            [ -n "$summary" ] && printf "  %-45s | %s\n" "$label" "$summary" >> /tmp/summary.log
-            return $rc
+            [ -n "$summary" ] && printf "%-50s | %s\n" "$label" "$summary" >> /tmp/summary.log
+            if [ $rc -eq 0 ]; then
+              if ffprobe -v error -show_entries stream=codec_name "$outfile" 2>&1 | grep -q hevc; then
+                echo "PASS: $label (encode + probe)"
+                if ffmpeg -y -i "$outfile" -frames:v 5 -f rawvideo /dev/null 2>&1; then
+                  echo "PASS: $label (decode)"
+                else
+                  echo "FAIL: $label (decode failed)"; FAIL=$((FAIL+1))
+                fi
+              else
+                echo "FAIL: $label (not valid HEVC)"; FAIL=$((FAIL+1))
+              fi
+            else
+              echo "FAIL: $label (encode failed)"; FAIL=$((FAIL+1))
+            fi
+            rm -f "$outfile"
           }
-          echo "" > /tmp/summary.log
-          run_x265 "10-bit ultrafast CRF"   $X265_10 --preset ultrafast --crf 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv  || FAIL=$((FAIL+1))
-          run_x265 "10-bit medium CRF"      $X265_10 --preset medium   --crf 22 --ssim --psnr --input-res 832x480 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_832x480.yuv   || FAIL=$((FAIL+1))
-          run_x265 "10-bit slow ABR + VBV"  $X265_10 --preset slow     --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_832x480.yuv || FAIL=$((FAIL+1))
-          run_x265 "10-bit veryslow CRF"    $X265_10 --preset veryslow --crf 18 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv   || FAIL=$((FAIL+1))
-          run_x265 "10-bit lossless"        $X265_10 --preset ultrafast --lossless             --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv   || FAIL=$((FAIL+1))
-          run_x265 "10-bit CQP"             $X265_10 --preset medium   --qp 28 --ssim --psnr  --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv   || FAIL=$((FAIL+1))
-          run_x265 "10-bit 2-pass pass1"    $X265_10 --preset medium   --bitrate 500 --pass 1 -F4 --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /dev/null testdata/test_10bit_416x240.yuv   || FAIL=$((FAIL+1))
-          run_x265 "10-bit 2-pass pass2"    $X265_10 --preset medium   --bitrate 500 --pass 2 -F4 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1))
-          run_x265 "10-bit tune grain"      $X265_10 --preset medium   --tune grain --crf 22 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1))
-          rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
-          run_x265 "12-bit ultrafast CRF"   $X265_12 --preset ultrafast --crf 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv  || FAIL=$((FAIL+1))
-          run_x265 "12-bit medium CRF"      $X265_12 --preset medium   --crf 22 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv   || FAIL=$((FAIL+1))
-          run_x265 "12-bit slow CRF"        $X265_12 --preset slow     --crf 20 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv   || FAIL=$((FAIL+1))
-          run_x265 "12-bit lossless"        $X265_12 --preset ultrafast --lossless             --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv   || FAIL=$((FAIL+1))
-          run_x265 "12-bit ABR + VBV"       $X265_12 --preset medium   --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 -F4 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1))
-          rm -f /tmp/out.hevc
-          echo ""
-          echo "==================== ENCODING SUMMARY ===================="
-          cat /tmp/summary.log 2>/dev/null || true
-          echo "=========================================================="
-          echo "=== 10-bit/12-bit Encoding Results FAIL=$FAIL ==="
-          mkdir -p summaries && cp /tmp/summary.log summaries/10bit-12bit-encoding.log 2>/dev/null || true
+          validate_encode "CRF ultrafast" --preset ultrafast --crf 28              --input-res 416x240 --fps 30 --frames 30
+          validate_encode "CRF medium"    --preset medium   --crf 22              --input-res 416x240 --fps 30 --frames 30
+          validate_encode "CRF veryslow"  --preset veryslow --crf 18              --input-res 416x240 --fps 30 --frames 30
+          validate_encode "ABR + VBV"     --preset medium   --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 -F4 --input-res 416x240 --fps 30 --frames 30
+          validate_encode "Lossless"      --preset ultrafast --lossless            --input-res 416x240 --fps 30 --frames 30
+          validate_encode "HRD compliant" --preset medium   --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 --hrd --aud --repeat-headers -F4 --input-res 416x240 --fps 30 --frames 30
+          validate_encode "Closed GOP"    --preset medium   --no-open-gop --keyint 10 --crf 28 --input-res 416x240 --fps 30 --frames 30
+          validate_encode "Zero-latency"  --preset medium   --tune zerolatency --crf 28 --input-res 416x240 --fps 30 --frames 30
+          echo "" >> /tmp/summary.log
+          echo "### Real-World Video (Y4M)" >> /tmp/summary.log
+          /tmp/run_x265.sh "bus ultrafast CRF 28"    $X265 --preset ultrafast --crf 28 --ssim --psnr --frames 150 -o artifacts/bus_ultrafast_crf28.hevc    testdata/xiph/bus_cif.y4m   || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "bus medium CRF 22"       $X265 --preset medium   --crf 22 --ssim --psnr --frames 150 -o artifacts/bus_medium_crf22.hevc        testdata/xiph/bus_cif.y4m   || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "bus slow ABR 1000k"      $X265 --preset slow     --bitrate 1000 --vbv-maxrate 1500 --vbv-bufsize 2000 -F4 --ssim --psnr --frames 150 -o artifacts/bus_slow_abr1000k.hevc testdata/xiph/bus_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "bus veryslow tune grain" $X265 --preset veryslow --tune grain --crf 20 --ssim --psnr --frames 60 -o artifacts/bus_veryslow_grain.hevc testdata/xiph/bus_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "akiyo medium CRF 22"     $X265 --preset medium   --crf 22 --ssim --psnr --frames 300 -o artifacts/akiyo_medium_crf22.hevc      testdata/xiph/akiyo_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "akiyo ultrafast VBV 500k CBR" $X265 --preset ultrafast     --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 --strict-cbr -F4 --ssim --psnr --frames 300 -o artifacts/akiyo_ultrafast_vbv500k.hevc testdata/xiph/akiyo_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "akiyo medium CRF 18"   $X265 --preset medium --crf 18 --ssim --psnr --frames 300 -o artifacts/akiyo_medium_crf18.hevc    testdata/xiph/akiyo_cif.y4m || FAIL=$((FAIL+1))
+          echo "=== Validate HEVC bitstreams ==="
+          for f in artifacts/*.hevc; do
+            if ffprobe -v error -show_entries stream=codec_name "$f" 2>&1 | grep -q hevc; then
+              echo "PASS: $f is valid HEVC"
+            else
+              echo "FAIL: $f is NOT valid HEVC"; FAIL=$((FAIL+1))
+            fi
+          done
+          rm -rf artifacts
+          echo "=== Video & Validation Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - Threading & Parallelism
+        if: matrix.category == 'threading'
+        run: |
+          X265=$(pwd)/dist/8bit/x265
+          FAIL=0
+          echo "### Threading & Parallelism" >> /tmp/summary.log
+          /tmp/run_x265.sh "WPP enabled"            $X265 --preset medium --wpp    --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "WPP disabled"           $X265 --preset medium --no-wpp --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          for ft in 1 2 4; do
+            /tmp/run_x265.sh "Frame threads $ft"    $X265 --preset medium --frame-threads $ft   --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for ls in 0 2 4; do
+            /tmp/run_x265.sh "Lookahead slices $ls" $X265 --preset medium --lookahead-slices $ls --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          /tmp/run_x265.sh "Pools=none"             $X265 --preset ultrafast --pools none --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "=== Threading Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - 10-bit & 12-bit Encoding
+        if: matrix.category == 'hbd'
+        run: |
+          X265_10=$(pwd)/dist/10bit/x265
+          X265_12=$(pwd)/dist/12bit/x265
+          FAIL=0
+          echo "### 10-bit Encoding" >> /tmp/summary.log
+          /tmp/run_x265.sh "10-bit ultrafast CRF"  $X265_10 --preset ultrafast --crf 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit medium CRF"     $X265_10 --preset medium   --crf 22 --ssim --psnr --input-res 832x480 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit slow ABR + VBV" $X265_10 --preset slow     --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit veryslow CRF"   $X265_10 --preset veryslow --crf 18 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit lossless"       $X265_10 --preset ultrafast --lossless --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit CQP"            $X265_10 --preset medium   --qp 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit 2-pass pass1"   $X265_10 --preset medium   --bitrate 500 --pass 1 -F4 --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /dev/null testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "10-bit 2-pass pass2"   $X265_10 --preset medium   --bitrate 500 --pass 2 -F4 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
+          /tmp/run_x265.sh "10-bit tune grain"     $X265_10 --preset medium   --tune grain --crf 22 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "" >> /tmp/summary.log
+          echo "### 12-bit Encoding" >> /tmp/summary.log
+          /tmp/run_x265.sh "12-bit ultrafast CRF"  $X265_12 --preset ultrafast --crf 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit medium CRF"     $X265_12 --preset medium   --crf 22 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit slow CRF"       $X265_12 --preset slow     --crf 20 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit lossless"       $X265_12 --preset ultrafast --lossless --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit ABR + VBV"      $X265_12 --preset medium   --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 -F4 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "=== 10-bit/12-bit Results FAIL=$FAIL ==="
           test $FAIL -eq 0
 
       - name: Write step summary
         if: always()
         run: |
           {
-            echo "## 10-bit & 12-bit Encoding"
+            echo "## AArch64 – ${{ matrix.category }}"
             echo ""
-            echo "| Test | Depth | Frames | FPS | Bitrate (kb/s) | Avg QP |"
-            echo "|------|:-----:|-------:|----:|---------------:|-------:|"
-            if [ -f /tmp/summary.log ] && grep -qv '^[[:space:]]*$' /tmp/summary.log 2>/dev/null; then
-              while IFS= read -r line; do
-                [ -z "${line//[[:space:]]/}" ] && continue
-                label=$(echo "$line" | sed 's/^ *//' | cut -d'|' -f1 | sed 's/ *$//')
-                rest=$(echo "$line" | cut -d'|' -f2-)
-                frames=$(echo "$rest" | grep -oP 'encoded \K\d+' || true)
-                fps=$(echo "$rest" | grep -oP '\(\K[\d.]+(?= fps\))' || true)
-                bitrate=$(echo "$rest" | grep -oP '[\d.]+(?= kb/s)' || true)
-                qp=$(echo "$rest" | grep -oP 'Avg QP:\K[\d.]+' || true)
-                depth=$(echo "$label" | grep -oP '^\d+' || echo '-')
-                echo "| \`${label:-?}\` | ${depth} | ${frames:--} | ${fps:--} | ${bitrate:--} | ${qp:--} |"
-              done < /tmp/summary.log
+            if [ ! -f /tmp/summary.log ] || ! grep -qv '^[[:space:]]*$' /tmp/summary.log 2>/dev/null; then
+              echo "_No data collected._"
             else
-              echo "| _no data_ | | | | | |"
+              while IFS= read -r line; do
+                if [[ "$line" == "###"* ]]; then
+                  echo ""
+                  echo "$line"
+                  echo ""
+                  echo "| Test | Frames | FPS | Bitrate (kb/s) | Avg QP |"
+                  echo "|------|-------:|----:|---------------:|-------:|"
+                  continue
+                fi
+                [ -z "${line//[[:space:]]/}" ] && continue
+                label=$(echo "$line" | cut -d'|' -f1 | sed 's/^ *//;s/ *$//')
+                rest=$(echo "$line"  | cut -d'|' -f2-)
+                frames=$(echo "$rest"  | grep -oE 'encoded [0-9]+'        | grep -oE '[0-9]+$' || true)
+                fps=$(echo "$rest"     | perl -ne 'print $1 if /\(([\d.]+) fps\)/' || true)
+                bitrate=$(echo "$rest" | perl -ne 'print $1 if /([\d.]+) kb\/s/'   || true)
+                qp=$(echo "$rest"      | perl -ne 'print $1 if /Avg QP:([\d.]+)/'  || true)
+                echo "| \`${label:-?}\` | ${frames:--} | ${fps:--} | ${bitrate:--} | ${qp:--} |"
+              done < /tmp/summary.log
             fi
-            echo ""
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prepare summary artifact
+        if: always() && github.event_name != 'pull_request_target'
+        run: |
+          mkdir -p summaries
+          cp /tmp/summary.log summaries/aarch64-${{ matrix.category }}.log 2>/dev/null || touch summaries/aarch64-${{ matrix.category }}.log
 
       - name: Upload summaries
         if: always() && github.event_name != 'pull_request_target'
         uses: actions/upload-artifact@v7
         with:
-          name: summaries-10bit-12bit-encoding
+          name: summaries-aarch64-${{ matrix.category }}
+          path: summaries/*.log
+          retention-days: 3
+
+  # ───────────────────────────────────────────────────────────────────────────
+
+  test-windows:
+    name: "Test Windows (${{ matrix.category }})"
+    runs-on: windows-latest
+    timeout-minutes: 60
+    needs: build-windows
+    strategy:
+      fail-fast: false
+      matrix:
+        category: [presets-tune, rate-control, encoding-features, analysis-reuse, real-world, threading, hbd]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Download 8-bit binary
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-windows-8bit
+          path: dist/8bit
+
+      - name: Download 10-bit binary
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-windows-10bit
+          path: dist/10bit
+
+      - name: Download 12-bit binary
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-windows-12bit
+          path: dist/12bit
+
+      - name: Install ffmpeg
+        shell: pwsh
+        run: choco install ffmpeg -y
+
+      - name: Generate test data
+        run: |
+          mkdir -p testdata
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv420p     testdata/test_8bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=832x480:rate=30  -pix_fmt yuv420p     testdata/test_8bit_832x480.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv422p     testdata/test_422_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv444p     testdata/test_444_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv420p10le testdata/test_10bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=832x480:rate=30  -pix_fmt yuv420p10le testdata/test_10bit_832x480.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=416x240:rate=30  -pix_fmt yuv420p12le testdata/test_12bit_416x240.yuv
+          ffmpeg -y -f lavfi -i testsrc=duration=3:size=1920x1080:rate=25 -pix_fmt yuv420p    testdata/test_8bit_1080p.yuv
+
+      - name: Cache xiph.org test videos
+        id: cache-videos
+        uses: actions/cache@v5
+        with:
+          path: testdata/xiph
+          key: xiph-test-videos-v1
+      - name: Download xiph test videos (cache miss only)
+        if: steps.cache-videos.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p testdata/xiph
+          curl -sSL --retry 3 --max-time 60 -o testdata/xiph/bus_cif.y4m   https://media.xiph.org/video/derf/y4m/bus_cif.y4m
+          curl -sSL --retry 3 --max-time 60 -o testdata/xiph/akiyo_cif.y4m https://media.xiph.org/video/derf/y4m/akiyo_cif.y4m
+
+      - name: Define helper
+        run: |
+          cat > /tmp/run_x265.sh << 'HELPER'
+          #!/usr/bin/env bash
+          label="$1"; shift
+          echo "=== $label ==="
+          "$@" 2>&1 | tee /tmp/x265_last.log
+          rc=${PIPESTATUS[0]}
+          summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
+          [ -n "$summary" ] && printf "%-50s | %s\n" "$label" "$summary" >> /tmp/summary.log
+          exit $rc
+          HELPER
+          chmod +x /tmp/run_x265.sh
+
+      - name: Test - CLI Presets & Tune Modes
+        if: matrix.category == 'presets-tune'
+        run: |
+          X265=$(pwd)/dist/8bit/x265.exe
+          PASS=0; FAIL=0; TOTAL=0
+          echo "### Presets" >> /tmp/summary.log
+          for preset in ultrafast superfast veryfast faster fast medium slow slower veryslow; do
+            TOTAL=$((TOTAL + 1))
+            if /tmp/run_x265.sh "Preset $preset" "$X265" --preset $preset --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv; then
+              PASS=$((PASS + 1))
+            else
+              FAIL=$((FAIL + 1))
+            fi
+            rm -f /tmp/out.hevc
+          done
+          echo "" >> /tmp/summary.log
+          echo "### Tune Modes" >> /tmp/summary.log
+          for tune in psnr ssim grain fastdecode zerolatency; do
+            TOTAL=$((TOTAL + 1))
+            if /tmp/run_x265.sh "Tune $tune" "$X265" --preset medium --tune $tune --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv; then
+              PASS=$((PASS + 1))
+            else
+              FAIL=$((FAIL + 1))
+            fi
+            rm -f /tmp/out.hevc
+          done
+          echo "=== Preset/Tune Results $PASS/$TOTAL passed, $FAIL failed ==="
+          test $FAIL -eq 0
+
+      - name: Test - Rate Control Modes
+        if: matrix.category == 'rate-control'
+        run: |
+          X265=$(pwd)/dist/8bit/x265.exe
+          FAIL=0
+          echo "### Rate Control" >> /tmp/summary.log
+          /tmp/run_x265.sh "CRF Mode"                   "$X265" --preset medium --crf 22 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "CQP Mode"                   "$X265" --preset medium --qp 28  --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "ABR Mode"                   "$X265" --preset medium --bitrate 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "VBV Constrained"            "$X265" --preset medium --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Strict CBR"                 "$X265" --preset medium --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 --strict-cbr -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "CRF + VBV"                  "$X265" --preset medium --crf 22 --vbv-maxrate 2000 --vbv-bufsize 3000 --crf-max 32 --crf-min 18 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "2-pass p1"                  "$X265" --preset medium --bitrate 1000 --pass 1 -F4 --input-res 832x480 --fps 30 --frames 60 -o NUL testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "2-pass p2"                  "$X265" --preset medium --bitrate 1000 --pass 2 -F4 --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
+          /tmp/run_x265.sh "Multi-pass Opt Analysis p1" "$X265" --preset medium --bitrate 1000 --pass 1 --multi-pass-opt-analysis --input-res 832x480 --fps 30 --frames 60 -o NUL testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "Multi-pass Opt Analysis p2" "$X265" --preset medium --bitrate 1000 --pass 2 --multi-pass-opt-analysis --ssim --psnr --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
+          echo "=== Rate Control Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - Encoding Features
+        if: matrix.category == 'encoding-features'
+        run: |
+          X265=$(pwd)/dist/8bit/x265.exe
+          FAIL=0
+          echo "### Encoding Features" >> /tmp/summary.log
+          /tmp/run_x265.sh "Lossless"           "$X265" --preset ultrafast --lossless --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "CU Lossless"        "$X265" --preset medium --crf 22 --cu-lossless --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          for ctu in 16 32 64; do
+            /tmp/run_x265.sh "CTU $ctu"         "$X265" --preset medium --ctu $ctu --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for aqmode in 0 3; do
+            /tmp/run_x265.sh "AQ Mode $aqmode"  "$X265" --preset medium --aq-mode $aqmode --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for me in hex umh full; do
+            /tmp/run_x265.sh "ME $me"           "$X265" --preset medium --me $me --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          /tmp/run_x265.sh "SAO + Deblock"      "$X265" --preset medium --sao --deblock 2:2 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "No SAO/Deblock"     "$X265" --preset medium --no-sao --no-deblock --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Limit SAO"          "$X265" --preset medium --limit-sao --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Weighted P+B"       "$X265" --preset medium --weightp --weightb --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "B-frames 0"         "$X265" --preset medium --bframes 0  --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "B-frames 16"        "$X265" --preset medium --bframes 16 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Infinite Keyint"    "$X265" --preset medium --keyint -1 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Short Keyint"       "$X265" --preset medium --keyint 10 --min-keyint 5 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Closed GOP"         "$X265" --preset medium --no-open-gop --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Constrained Intra"  "$X265" --preset medium --constrained-intra --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          for rd in 2 5; do
+            /tmp/run_x265.sh "RD Level $rd"     "$X265" --preset medium --rd $rd --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for rdoq in 0 2; do
+            /tmp/run_x265.sh "RDOQ Level $rdoq" "$X265" --preset medium --rdoq-level $rdoq --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          /tmp/run_x265.sh "Scaling List"       "$X265" --preset medium --scaling-list default --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Noise Reduction"    "$X265" --preset medium --nr-intra 500 --nr-inter 300 -F4 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Psy-RD + Psy-RDOQ" "$X265" --preset medium --psy-rd 1.5 --psy-rdoq 1.0 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "No Psy"             "$X265" --preset medium --no-psy-rd --no-psy-rdoq --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Multiple Slices"    "$X265" --preset medium --slices 4 --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Temporal Layers"    "$X265" --preset medium --temporal-layers 3 --b-adapt 0 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "HEVC-AQ"            "$X265" --preset medium --hevc-aq --no-cutree --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "HME"                "$X265" --preset medium --hme --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Lowpass DCT"        "$X265" --preset medium --lowpass-dct --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Streaming Flags"    "$X265" --preset medium --hrd --aud --repeat-headers --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "422 Input"          "$X265" --preset medium --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_422_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "444 Input"          "$X265" --preset medium --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_444_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Segment Encoding"   "$X265" --preset ultrafast --no-open-gop --chunk-start 10 --chunk-end 50 --crf 28 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "" >> /tmp/summary.log
+          echo "### Quality Metrics" >> /tmp/summary.log
+          /tmp/run_x265.sh "SSIM Metric"  "$X265" --preset medium --ssim        --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1))
+          grep -qi "ssim" /tmp/x265_last.log || { echo "FAIL: ssim not reported"; FAIL=$((FAIL+1)); }; rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "PSNR Metric"  "$X265" --preset medium --psnr        --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1))
+          grep -qi "psnr" /tmp/x265_last.log || { echo "FAIL: psnr not reported"; FAIL=$((FAIL+1)); }; rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "SSIM + PSNR"  "$X265" --preset medium --ssim --psnr --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Hash (MD5)"   "$X265" --preset medium --hash 1      --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Recon Output" "$X265" --preset medium               --crf 22 --input-res 416x240 --fps 30 --frames 30 -o /tmp/out.hevc -r /tmp/recon.yuv testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1))
+          test -f /tmp/recon.yuv || { echo "FAIL: recon file missing"; FAIL=$((FAIL+1)); }; rm -f /tmp/out.hevc /tmp/recon.yuv
+          echo "" >> /tmp/summary.log
+          echo "### MCSTF, SBRC & Interlace" >> /tmp/summary.log
+          /tmp/run_x265.sh "MCSTF slower"          "$X265" --preset slower    --crf 24 --mcstf --bframes 5 --frame-threads 1 --no-cutree --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "MCSTF medium"          "$X265" --preset medium    --crf 26 --mcstf --bframes 5 --frame-threads 1 --tskip-fast --constrained-intra --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "MCSTF slow"            "$X265" --preset slow      --crf 24 --mcstf --bframes 5 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "SBRC slow"             "$X265" --preset slow      --crf 26 --sbrc --no-open-gop --keyint 60 --min-keyint 60 --vbv-bufsize 6000 --vbv-maxrate 5000 --temporal-layers 4 --b-adapt 0 --no-cutree --input-res 1920x1080 --fps 25 --frames 50 -o /tmp/out.hevc testdata/test_8bit_1080p.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "SBRC superfast"        "$X265" --preset superfast --crf 22 --sbrc --no-open-gop --vbv-maxrate 9000 --vbv-bufsize 7500 --keyint 100 --min-keyint 100 --input-res 1920x1080 --fps 25 --frames 50 -o /tmp/out.hevc testdata/test_8bit_1080p.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Interlace TFF"         "$X265" --preset faster    --interlace tff --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Interlace BFF"         "$X265" --preset fast      --interlace bff --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Interlace BFF+weightb" "$X265" --preset fast      --interlace bff --weightb --crf 28 --input-res 832x480 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "=== Encoding Features Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - Analysis Save/Load
+        if: matrix.category == 'analysis-reuse'
+        run: |
+          X265=$(pwd)/dist/8bit/x265.exe
+          FAIL=0
+          echo "### Analysis Save/Load" >> /tmp/summary.log
+          /tmp/run_x265.sh "Analysis Save (level 2)"  "$X265" --preset medium --analysis-save x265_analysis.dat    --analysis-save-reuse-level 2  --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Analysis Load (level 2)"  "$X265" --preset medium --analysis-load x265_analysis.dat    --analysis-load-reuse-level 2  --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Analysis Save (level 10)" "$X265" --preset slow   --analysis-save x265_analysis_10.dat --analysis-save-reuse-level 10 --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "Analysis Load (level 10)" "$X265" --preset slow   --analysis-load x265_analysis_10.dat --analysis-load-reuse-level 10 --bitrate 500 --input-res 416x240 --fps 30 --frames 60 -o /tmp/out.hevc testdata/test_8bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_analysis*.dat
+          echo "=== Analysis Save/Load Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - Real-World Video & Bitstream Validation
+        if: matrix.category == 'real-world'
+        run: |
+          X265=$(pwd)/dist/8bit/x265.exe
+          FAIL=0
+          mkdir -p artifacts
+          echo "### Bitstream Validation" >> /tmp/summary.log
+          validate_encode() {
+            local label="$1"; shift
+            echo "=== $label ==="
+            local outfile="/tmp/validate_${RANDOM}.hevc"
+            "$X265" "$@" -o "$outfile" testdata/test_8bit_416x240.yuv 2>&1 | tee /tmp/x265_last.log
+            local rc=${PIPESTATUS[0]}
+            local summary=$(grep "encoded" /tmp/x265_last.log | tail -1)
+            [ -n "$summary" ] && printf "%-50s | %s\n" "$label" "$summary" >> /tmp/summary.log
+            if [ $rc -eq 0 ]; then
+              if ffprobe -v error -show_entries stream=codec_name "$outfile" 2>&1 | grep -q hevc; then
+                echo "PASS: $label (encode + probe)"
+                if ffmpeg -y -i "$outfile" -frames:v 5 -f rawvideo NUL 2>&1; then
+                  echo "PASS: $label (decode)"
+                else
+                  echo "FAIL: $label (decode failed)"; FAIL=$((FAIL+1))
+                fi
+              else
+                echo "FAIL: $label (not valid HEVC)"; FAIL=$((FAIL+1))
+              fi
+            else
+              echo "FAIL: $label (encode failed)"; FAIL=$((FAIL+1))
+            fi
+            rm -f "$outfile"
+          }
+          validate_encode "CRF ultrafast" --preset ultrafast --crf 28              --input-res 416x240 --fps 30 --frames 30
+          validate_encode "CRF medium"    --preset medium   --crf 22              --input-res 416x240 --fps 30 --frames 30
+          validate_encode "CRF veryslow"  --preset veryslow --crf 18              --input-res 416x240 --fps 30 --frames 30
+          validate_encode "ABR + VBV"     --preset medium   --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 -F4 --input-res 416x240 --fps 30 --frames 30
+          validate_encode "Lossless"      --preset ultrafast --lossless            --input-res 416x240 --fps 30 --frames 30
+          validate_encode "HRD compliant" --preset medium   --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 --hrd --aud --repeat-headers -F4 --input-res 416x240 --fps 30 --frames 30
+          validate_encode "Closed GOP"    --preset medium   --no-open-gop --keyint 10 --crf 28 --input-res 416x240 --fps 30 --frames 30
+          validate_encode "Zero-latency"  --preset medium   --tune zerolatency --crf 28 --input-res 416x240 --fps 30 --frames 30
+          echo "" >> /tmp/summary.log
+          echo "### Real-World Video (Y4M)" >> /tmp/summary.log
+          /tmp/run_x265.sh "bus ultrafast CRF 28"    "$X265" --preset ultrafast --crf 28 --ssim --psnr --frames 150 -o artifacts/bus_ultrafast_crf28.hevc    testdata/xiph/bus_cif.y4m   || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "bus medium CRF 22"       "$X265" --preset medium   --crf 22 --ssim --psnr --frames 150 -o artifacts/bus_medium_crf22.hevc        testdata/xiph/bus_cif.y4m   || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "bus slow ABR 1000k"      "$X265" --preset slow     --bitrate 1000 --vbv-maxrate 1500 --vbv-bufsize 2000 -F4 --ssim --psnr --frames 150 -o artifacts/bus_slow_abr1000k.hevc testdata/xiph/bus_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "bus veryslow tune grain" "$X265" --preset veryslow --tune grain --crf 20 --ssim --psnr --frames 150 -o artifacts/bus_veryslow_grain.hevc testdata/xiph/bus_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "akiyo medium CRF 22"     "$X265" --preset medium   --crf 22 --ssim --psnr --frames 300 -o artifacts/akiyo_medium_crf22.hevc      testdata/xiph/akiyo_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "akiyo slow VBV 500k CBR" "$X265" --preset slow     --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 --strict-cbr -F4 --ssim --psnr --frames 300 -o artifacts/akiyo_slow_vbv500k.hevc testdata/xiph/akiyo_cif.y4m || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "akiyo veryslow CRF 18"   "$X265" --preset veryslow --crf 18 --ssim --psnr --frames 300 -o artifacts/akiyo_veryslow_crf18.hevc    testdata/xiph/akiyo_cif.y4m || FAIL=$((FAIL+1))
+          echo "=== Validate HEVC bitstreams ==="
+          for f in artifacts/*.hevc; do
+            if ffprobe -v error -show_entries stream=codec_name "$f" 2>&1 | grep -q hevc; then
+              echo "PASS: $f is valid HEVC"
+            else
+              echo "FAIL: $f is NOT valid HEVC"; FAIL=$((FAIL+1))
+            fi
+          done
+          rm -rf artifacts
+          echo "=== Video & Validation Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - Threading & Parallelism
+        if: matrix.category == 'threading'
+        run: |
+          X265=$(pwd)/dist/8bit/x265.exe
+          FAIL=0
+          echo "### Threading & Parallelism" >> /tmp/summary.log
+          /tmp/run_x265.sh "WPP enabled"            "$X265" --preset medium --wpp    --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "WPP disabled"           "$X265" --preset medium --no-wpp --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          for ft in 1 2 4; do
+            /tmp/run_x265.sh "Frame threads $ft"    "$X265" --preset medium --frame-threads $ft   --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          for ls in 0 2 4; do
+            /tmp/run_x265.sh "Lookahead slices $ls" "$X265" --preset medium --lookahead-slices $ls --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          done
+          /tmp/run_x265.sh "Pools=none"             "$X265" --preset ultrafast --pools none --crf 28 --input-res 832x480 --fps 30 --frames 30 -o /tmp/out.hevc testdata/test_8bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "=== Threading Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Test - 10-bit & 12-bit Encoding
+        if: matrix.category == 'hbd'
+        run: |
+          X265_10=$(pwd)/dist/10bit/x265.exe
+          X265_12=$(pwd)/dist/12bit/x265.exe
+          FAIL=0
+          echo "### 10-bit Encoding" >> /tmp/summary.log
+          /tmp/run_x265.sh "10-bit ultrafast CRF"  "$X265_10" --preset ultrafast --crf 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit medium CRF"     "$X265_10" --preset medium   --crf 22 --ssim --psnr --input-res 832x480 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit slow ABR + VBV" "$X265_10" --preset slow     --bitrate 1000 --vbv-maxrate 1000 --vbv-bufsize 1000 -F4 --ssim --psnr --input-res 832x480 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_832x480.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit veryslow CRF"   "$X265_10" --preset veryslow --crf 18 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit lossless"       "$X265_10" --preset ultrafast --lossless --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit CQP"            "$X265_10" --preset medium   --qp 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "10-bit 2-pass pass1"   "$X265_10" --preset medium   --bitrate 500 --pass 1 -F4 --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o NUL testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1))
+          /tmp/run_x265.sh "10-bit 2-pass pass2"   "$X265_10" --preset medium   --bitrate 500 --pass 2 -F4 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc x265_2pass.log x265_2pass.log.cutree
+          /tmp/run_x265.sh "10-bit tune grain"     "$X265_10" --preset medium   --tune grain --crf 22 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 10 --frames 30 -o /tmp/out.hevc testdata/test_10bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "" >> /tmp/summary.log
+          echo "### 12-bit Encoding" >> /tmp/summary.log
+          /tmp/run_x265.sh "12-bit ultrafast CRF"  "$X265_12" --preset ultrafast --crf 28 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit medium CRF"     "$X265_12" --preset medium   --crf 22 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit slow CRF"       "$X265_12" --preset slow     --crf 20 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit lossless"       "$X265_12" --preset ultrafast --lossless --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          /tmp/run_x265.sh "12-bit ABR + VBV"      "$X265_12" --preset medium   --bitrate 500 --vbv-maxrate 500 --vbv-bufsize 500 -F4 --ssim --psnr --input-res 416x240 --fps 30 --input-depth 12 --frames 30 -o /tmp/out.hevc testdata/test_12bit_416x240.yuv || FAIL=$((FAIL+1)); rm -f /tmp/out.hevc
+          echo "=== 10-bit/12-bit Results FAIL=$FAIL ==="
+          test $FAIL -eq 0
+
+      - name: Write step summary
+        if: always()
+        run: |
+          {
+            echo "## Windows – ${{ matrix.category }}"
+            echo ""
+            if [ ! -f /tmp/summary.log ] || ! grep -qv '^[[:space:]]*$' /tmp/summary.log 2>/dev/null; then
+              echo "_No data collected._"
+            else
+              while IFS= read -r line; do
+                if [[ "$line" == "###"* ]]; then
+                  echo ""
+                  echo "$line"
+                  echo ""
+                  echo "| Test | Frames | FPS | Bitrate (kb/s) | Avg QP |"
+                  echo "|------|-------:|----:|---------------:|-------:|"
+                  continue
+                fi
+                [ -z "${line//[[:space:]]/}" ] && continue
+                label=$(echo "$line" | cut -d'|' -f1 | sed 's/^ *//;s/ *$//')
+                rest=$(echo "$line"  | cut -d'|' -f2-)
+                frames=$(echo "$rest"  | grep -oE 'encoded [0-9]+'        | grep -oE '[0-9]+$' || true)
+                fps=$(echo "$rest"     | perl -ne 'print $1 if /\(([\d.]+) fps\)/' || true)
+                bitrate=$(echo "$rest" | perl -ne 'print $1 if /([\d.]+) kb\/s/'   || true)
+                qp=$(echo "$rest"      | perl -ne 'print $1 if /Avg QP:([\d.]+)/'  || true)
+                echo "| \`${label:-?}\` | ${frames:--} | ${fps:--} | ${bitrate:--} | ${qp:--} |"
+              done < /tmp/summary.log
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prepare summary artifact
+        if: always() && github.event_name != 'pull_request_target'
+        run: |
+          mkdir -p summaries
+          cp /tmp/summary.log summaries/windows-${{ matrix.category }}.log 2>/dev/null || touch summaries/windows-${{ matrix.category }}.log
+
+      - name: Upload summaries
+        if: always() && github.event_name != 'pull_request_target'
+        uses: actions/upload-artifact@v7
+        with:
+          name: summaries-windows-${{ matrix.category }}
           path: summaries/*.log
           retention-days: 3
 
@@ -1580,10 +2887,17 @@ jobs:
           path: assets/*.tar.gz
           retention-days: 1
 
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Smoke - Linux: reuses build-linux's already-built x265
+  # binaries by passing smoke-test.py's --no-make flag, which skips
+  # the harness's own build step entirely rather than having it
+  # compile fresh copies.
+  # ─────────────────────────────────────────────────────────────────────────────
+
   smoke-linux:
     name: "Smoke - Linux (${{ matrix.build }})"
     runs-on: ubuntu-latest
-    needs: [code-quality, prep-assets]
+    needs: [code-quality, prep-assets, build-linux-multilib]
     if: github.event_name == 'pull_request_target'
     timeout-minutes: 60
     strategy:
@@ -1672,17 +2986,45 @@ jobs:
       - name: "Install dependencies"
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y nasm libnuma-dev
+          sudo apt-get install -y libnuma-dev
           python3 -m pip install msal requests psutil --break-system-packages
           echo "[OK] Dependencies installed"
+
+      - name: "Download pre-built binary (${{ matrix.build }})"
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.build == 'gcc' && 'x265-linux-8bit' || matrix.build == 'gcc_8bit_debug' && 'x265-linux-8bit-debug' || matrix.build == 'gcc-main10' && 'x265-linux-10bit' || matrix.build == 'gcc_10bit_debug' && 'x265-linux-10bit-debug' || matrix.build == 'gccmain12' && 'x265-linux-12bit' || matrix.build == 'gccmain12_debug' && 'x265-linux-12bit-debug' || 'x265-linux-multilib' }}
+          path: prebuilt
+
+      - name: "Place pre-built binary for harness"
+        run: |
+          case "${{ matrix.build }}" in
+            gcc)              FOLDER="gcc" ;;
+            gcc_8bit_debug)   FOLDER="gcc_debug" ;;
+            gcc-main10)       FOLDER="gcc-main10" ;;
+            gcc_10bit_debug)  FOLDER="gcc10_debug" ;;
+            gccmain12)        FOLDER="gccmain12" ;;
+            gccmain12_debug)  FOLDER="gccmain12_debug" ;;
+            gcc-multilib)     FOLDER="gcc-multilib" ;;
+          esac
+          DEST_DIR="$HARNESS_DIR/x265/$FOLDER/default"
+          mkdir -p "$DEST_DIR"
+          cp prebuilt/x265 "$DEST_DIR/x265"
+          chmod +x "$DEST_DIR/x265"
+          # Copy all versioned .so files - the binary needs the versioned name (libx265.so.N.M), not just the symlink
+          if ls prebuilt/libx265.so* >/dev/null 2>&1; then
+            cp -P prebuilt/libx265.so* "$DEST_DIR/"
+            echo "LD_LIBRARY_PATH=$DEST_DIR:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+          fi
+          echo "[OK] Placed pre-built ${{ matrix.build }} binary at $DEST_DIR"
 
       - name: "Run smoke-test.py (${{ matrix.build }})"
         run: |
           cd "$HARNESS_DIR"
-          echo "=== Starting smoke test for build: ${{ matrix.build }} ==="
-          python3 smoke-test.py -b "${{ matrix.build }}" -t "$SMOKE_TESTS_FILE"
+          echo "=== Starting smoke test for build: ${{ matrix.build }} (pre-built binary, --no-make) ==="
+          python3 smoke-test.py -b "${{ matrix.build }}" -t "$SMOKE_TESTS_FILE" --no-make --no-bench
           echo "[OK] Linux smoke test PASSED for ${{ matrix.build }}"
-      
+
       - name: "Set log upload path"
         if: always()
         run: |
@@ -1697,10 +3039,16 @@ jobs:
           if-no-files-found: warn
           retention-days: 3
 
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Smoke - Windows: reuses build-windows's x265.exe/libx265.dll via
+  # --no-make, skipping the harness's own build. Expected at
+  # x265/<build>/default/<Release|Debug>/x265.exe
+  # ─────────────────────────────────────────────────────────────────────────────
+
   smoke-windows:
     name: "Smoke - Windows (${{ matrix.build }})"
     runs-on: windows-2022
-    needs: [code-quality, prep-assets]
+    needs: [code-quality, prep-assets, build-windows-multilib]
     if: github.event_name == 'pull_request_target'
     timeout-minutes: 60
     defaults:
@@ -1844,19 +3192,37 @@ jobs:
 
       - name: "Install dependencies"
         run: |
-          choco install nasm -y --no-progress
-          echo "C:\Program Files\NASM" >> $GITHUB_PATH
           python3 -m pip install msal requests psutil setuptools
           echo "[OK] Dependencies installed"
+
+      - name: "Download pre-built binary (${{ matrix.build }})"
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.build == 'vc17_64_8bpp' && 'x265-windows-8bit' || matrix.build == 'vc17_64_8bpp_debug' && 'x265-windows-8bit-debug' || matrix.build == 'vc17_64_16bpp' && 'x265-windows-10bit' || matrix.build == 'vc17_64_16bpp_debug' && 'x265-windows-10bit-debug' || matrix.build == 'vc17_64_main12' && 'x265-windows-12bit' || matrix.build == 'vc17_64_main12_debug' && 'x265-windows-12bit-debug' || 'x265-windows-multilib' }}
+          path: prebuilt
+
+      - name: "Place pre-built binary for harness"
+        run: |
+          case "${{ matrix.build }}" in
+            *_debug) TARGET="Debug" ;;
+            *)       TARGET="Release" ;;
+          esac
+          DEST_DIR="$HARNESS_DIR/x265/${{ matrix.build }}/default/$TARGET"
+          mkdir -p "$DEST_DIR"
+          cp prebuilt/x265.exe "$DEST_DIR/x265.exe"
+          if [ -f prebuilt/libx265.dll ]; then
+            cp prebuilt/libx265.dll "$DEST_DIR/libx265.dll"
+          fi
+          echo "[OK] Placed pre-built ${{ matrix.build }} binary at $DEST_DIR"
 
       - name: "Run smoke-test.py (${{ matrix.build }})"
         run: |
           cd "$HARNESS_DIR"
-          echo "=== Starting smoke test for build: ${{ matrix.build }} ==="
+          echo "=== Starting smoke test for build: ${{ matrix.build }} (pre-built binary, --no-make) ==="
           WIN_SMOKE_TESTS_FILE=$(cygpath -m "$SMOKE_TESTS_FILE")
-          python3 smoke-test.py -b "${{ matrix.build }}" -t "$WIN_SMOKE_TESTS_FILE"
+          python3 smoke-test.py -b "${{ matrix.build }}" -t "$WIN_SMOKE_TESTS_FILE" --no-make --no-bench
           echo "[OK] Windows smoke test PASSED for ${{ matrix.build }}"
-      
+
       - name: "Set log upload path"
         if: always()
         run: |
@@ -1871,14 +3237,14 @@ jobs:
           if-no-files-found: warn
           retention-days: 3
 
-  # ───────────────────────────────────────────────────────────────────────────
+  # ─────────────────────────────────────────────────────────────────────────────
   # Phase 3 – Summary report + Final PR gate (parallel)
   # Runs after all test jobs complete:
   # - On push/non-PR events: summary report aggregates all test logs into a
   #   GITHUB_STEP_SUMMARY performance report with FPS rankings and per-suite tables.
   # - On pull_request_target: final PR gate aggregates results from all jobs
   #   and reports overall PR validation status.
-  # ───────────────────────────────────────────────────────────────────────────
+  # ─────────────────────────────────────────────────────────────────────────────
 
   summary-report:
     name: "Pipeline Summary Report"
@@ -1886,14 +3252,10 @@ jobs:
     timeout-minutes: 5
     if: always() && github.event_name != 'pull_request_target'
     needs:
-      - build-multilib
-      - test-cli-presets
-      - test-rate-control
-      - test-encoding-features
-      - test-analysis-save-load
-      - test-video-and-validation
-      - test-threading
-      - test-10bit-12bit-encoding
+      - test-linux
+      - test-macos
+      - test-aarch64
+      - test-windows
     steps:
       - name: Download all summaries
         uses: actions/download-artifact@v8
@@ -1989,32 +3351,50 @@ jobs:
           fi
           w ""
 
-          # ── Per-suite tables ──
+          # ── Per-platform, per-suite tables ──
           w "---"
           w ""
 
           declare -A SUITE_TITLES
-          SUITE_TITLES["cli-presets"]="CLI Presets & Tune Modes"
+          SUITE_TITLES["presets-tune"]="CLI Presets & Tune Modes"
           SUITE_TITLES["rate-control"]="Rate Control Modes"
           SUITE_TITLES["encoding-features"]="Encoding Features (incl. Quality Metrics, MCSTF/SBRC/Interlace)"
-          SUITE_TITLES["analysis-save-load"]="Analysis Save/Load"
-          SUITE_TITLES["video-and-validation"]="Real-World Video & Bitstream Validation"
+          SUITE_TITLES["analysis-reuse"]="Analysis Save/Load"
+          SUITE_TITLES["real-world"]="Real-World Video & Bitstream Validation"
           SUITE_TITLES["threading"]="Threading & Parallelism"
-          SUITE_TITLES["10bit-12bit-encoding"]="10-bit & 12-bit Encoding"
+          SUITE_TITLES["hbd"]="10-bit & 12-bit Encoding"
 
-          # Fixed display order
-          for suite in cli-presets rate-control encoding-features analysis-save-load \
-                       video-and-validation threading 10bit-12bit-encoding; do
-            f="summaries/${suite}.log"
-            [ -f "$f" ] || continue
-            title="${SUITE_TITLES[$suite]:-$suite}"
-            count=$(grep -c '[^[:space:]]' "$f" 2>/dev/null || echo 0)
-            w "### $title ($count encodes)"
+          declare -A PLATFORM_TITLES
+          PLATFORM_TITLES["linux"]="Linux"
+          PLATFORM_TITLES["macos"]="macOS"
+          PLATFORM_TITLES["aarch64"]="AArch64"
+          PLATFORM_TITLES["windows"]="Windows"
+
+          # Fixed display order: platform, then category within each platform
+          for platform in linux macos aarch64 windows; do
+            ptitle="${PLATFORM_TITLES[$platform]}"
+            platform_has_data=false
+            for category in presets-tune rate-control encoding-features analysis-reuse \
+                             real-world threading hbd; do
+              [ -f "summaries/${platform}-${category}.log" ] && platform_has_data=true
+            done
+            $platform_has_data || continue
+
+            w "## $ptitle"
             w ""
-            w "| Test | Frames | FPS | Bitrate (kb/s) | Avg QP |"
-            w "|------|-------:|----:|---------------:|-------:|"
-            parse_log "$f" | tee -a "$GITHUB_STEP_SUMMARY"
-            w ""
+            for category in presets-tune rate-control encoding-features analysis-reuse \
+                             real-world threading hbd; do
+              f="summaries/${platform}-${category}.log"
+              [ -f "$f" ] || continue
+              title="${SUITE_TITLES[$category]:-$category}"
+              count=$(grep -c '[^[:space:]]' "$f" 2>/dev/null || echo 0)
+              w "### $title ($count encodes)"
+              w ""
+              w "| Test | Frames | FPS | Bitrate (kb/s) | Avg QP |"
+              w "|------|-------:|----:|---------------:|-------:|"
+              parse_log "$f" | tee -a "$GITHUB_STEP_SUMMARY"
+              w ""
+            done
           done
 
           # ── Console-only plain-text summary ──
@@ -2032,17 +3412,16 @@ jobs:
       - code-quality
       - smoke-linux
       - smoke-windows
-      - build-8bit
-      - build-10bit
-      - build-12bit
-      - build-multilib
-      - test-cli-presets
-      - test-rate-control
-      - test-encoding-features
-      - test-analysis-save-load
-      - test-video-and-validation
-      - test-threading
-      - test-10bit-12bit-encoding
+      - build-linux
+      - build-linux-multilib
+      - build-macos
+      - build-aarch64
+      - build-windows
+      - build-windows-multilib
+      - test-linux
+      - test-macos
+      - test-aarch64
+      - test-windows
     if: always() && (github.event_name == 'pull_request_target')
 
     steps:
@@ -2057,33 +3436,31 @@ jobs:
           echo "  Code Quality  : ${{ needs.code-quality.result }}"
           echo "  Smoke Linux   : ${{ needs.smoke-linux.result }}"
           echo "  Smoke Windows : ${{ needs.smoke-windows.result }}"
-          echo "  Build 8-bit   : ${{ needs.build-8bit.result }}"
-          echo "  Build 10-bit  : ${{ needs.build-10bit.result }}"
-          echo "  Build 12-bit  : ${{ needs.build-12bit.result }}"
-          echo "  Build Multilib: ${{ needs.build-multilib.result }}"
-          echo "  Test Presets  : ${{ needs.test-cli-presets.result }}"
-          echo "  Test Rate Ctrl: ${{ needs.test-rate-control.result }}"
-          echo "  Test Enc Feat : ${{ needs.test-encoding-features.result }}"
-          echo "  Test Analysis : ${{ needs.test-analysis-save-load.result }}"
-          echo "  Test Video    : ${{ needs.test-video-and-validation.result }}"
-          echo "  Test Threading: ${{ needs.test-threading.result }}"
-          echo "  Test 10/12bit : ${{ needs.test-10bit-12bit-encoding.result }}"
+          echo "  Build Linux   : ${{ needs.build-linux.result }}"
+          echo "  Build Linux Multilib   : ${{ needs.build-linux-multilib.result }}"
+          echo "  Build macOS   : ${{ needs.build-macos.result }}"
+          echo "  Build AArch64 : ${{ needs.build-aarch64.result }}"
+          echo "  Build Windows : ${{ needs.build-windows.result }}"
+          echo "  Build Windows Multilib : ${{ needs.build-windows-multilib.result }}"
+          echo "  Test Linux    : ${{ needs.test-linux.result }}"
+          echo "  Test macOS    : ${{ needs.test-macos.result }}"
+          echo "  Test AArch64  : ${{ needs.test-aarch64.result }}"
+          echo "  Test Windows  : ${{ needs.test-windows.result }}"
           echo "================================================"
           ALL_PASS=true
-          [[ "${{ needs.code-quality.result }}"            != "success" ]] && ALL_PASS=false && echo "   -> Code quality gate failed"
-          [[ "${{ needs.smoke-linux.result }}"             != "success" ]] && ALL_PASS=false && echo "   -> Linux smoke test failed - check uploaded log artifacts"
-          [[ "${{ needs.smoke-windows.result }}"           != "success" ]] && ALL_PASS=false && echo "   -> Windows smoke test failed - check uploaded log artifacts"
-          [[ "${{ needs.build-8bit.result }}"   != "success" ]] && ALL_PASS=false && echo "   -> 8-bit build failed"
-          [[ "${{ needs.build-10bit.result }}"  != "success" ]] && ALL_PASS=false && echo "   -> 10-bit build failed"
-          [[ "${{ needs.build-12bit.result }}"  != "success" ]] && ALL_PASS=false && echo "   -> 12-bit build failed"
-          [[ "${{ needs.build-multilib.result }}"          != "success" ]] && ALL_PASS=false && echo "   -> Multilib build failed"
-          [[ "${{ needs.test-cli-presets.result }}"        != "success" ]] && ALL_PASS=false && echo "   -> CLI presets test failed"
-          [[ "${{ needs.test-rate-control.result }}"       != "success" ]] && ALL_PASS=false && echo "   -> Rate control test failed"
-          [[ "${{ needs.test-encoding-features.result }}"  != "success" ]] && ALL_PASS=false && echo "   -> Encoding features test failed"
-          [[ "${{ needs.test-analysis-save-load.result }}" != "success" ]] && ALL_PASS=false && echo "   -> Analysis save/load test failed"
-          [[ "${{ needs.test-video-and-validation.result }}" != "success" ]] && ALL_PASS=false && echo "   -> Video & validation test failed"
-          [[ "${{ needs.test-threading.result }}"          != "success" ]] && ALL_PASS=false && echo "   -> Threading test failed"
-          [[ "${{ needs.test-10bit-12bit-encoding.result }}" != "success" ]] && ALL_PASS=false && echo "   -> 10/12-bit encoding test failed"
+          [[ "${{ needs.code-quality.result }}"    != "success" ]] && ALL_PASS=false && echo "   -> Code quality gate failed"
+          [[ "${{ needs.smoke-linux.result }}"     != "success" ]] && ALL_PASS=false && echo "   -> Linux smoke test failed - check uploaded log artifacts"
+          [[ "${{ needs.smoke-windows.result }}"   != "success" ]] && ALL_PASS=false && echo "   -> Windows smoke test failed - check uploaded log artifacts"
+          [[ "${{ needs.build-linux.result }}"     != "success" ]] && ALL_PASS=false && echo "   -> Linux build failed (Release or Debug leg)"
+          [[ "${{ needs.build-linux-multilib.result }}"   != "success" ]] && ALL_PASS=false && echo "   -> Linux multilib build failed"
+          [[ "${{ needs.build-macos.result }}"     != "success" ]] && ALL_PASS=false && echo "   -> macOS build failed"
+          [[ "${{ needs.build-aarch64.result }}"   != "success" ]] && ALL_PASS=false && echo "   -> AArch64 build failed"
+          [[ "${{ needs.build-windows.result }}"   != "success" ]] && ALL_PASS=false && echo "   -> Windows build failed (Release or Debug leg)"
+          [[ "${{ needs.build-windows-multilib.result }}" != "success" ]] && ALL_PASS=false && echo "   -> Windows multilib build failed"
+          [[ "${{ needs.test-linux.result }}"      != "success" ]] && ALL_PASS=false && echo "   -> Linux tests failed"
+          [[ "${{ needs.test-macos.result }}"      != "success" ]] && ALL_PASS=false && echo "   -> macOS tests failed"
+          [[ "${{ needs.test-aarch64.result }}"    != "success" ]] && ALL_PASS=false && echo "   -> AArch64 tests failed"
+          [[ "${{ needs.test-windows.result }}"    != "success" ]] && ALL_PASS=false && echo "   -> Windows tests failed"
           if $ALL_PASS; then
             echo "[OK] ALL CHECKS PASSED - READY TO MERGE"
           else


### PR DESCRIPTION
## Summary

Expands the x265 CI pipeline from Linux-only to four platforms (Linux, macOS, AArch64 cross+QEMU, Windows), consolidates the per-suite test jobs into a per-platform test matrix, and cuts wall-clock time through build caching, parallelized multilib linking, and smoke-test binary reuse.

## What changed

**Platform coverage**
- Added macOS (native, Apple Silicon), AArch64 (cross-compiled + QEMU user-mode), and Windows (MSVC) build + test jobs, matching the existing Linux job's matrix shape (8-bit / 10-bit / 12-bit / multilib).
- Consolidated the seven separate per-suite test jobs (`test-cli-presets`, `test-rate-control`, …) into one job per platform with a `category` matrix (`presets-tune`, `rate-control`, `encoding-features`, `analysis-reuse`, `real-world`, `threading`, `hbd`).

**Build matrix**
- Added Debug builds alongside the existing Release builds, as a new `config: [Release, Debug]` matrix dimension on Linux and Windows.
- Parallelized multilib linking: the 12-bit/10-bit components now build as extra parallel legs of the main build matrix (`build-linux`/`build-windows`); a thin `build-linux-multilib`/`build-windows-multilib` job downloads both component libs and does only the final 8-bit link step. Previously all three steps ran sequentially in one job.

**Caching**
- ccache/sccache keys are now scoped by PR number (in addition to branch/variant), preventing cross-PR cache poisoning under `pull_request_target`, whose cache scope is otherwise tied only to the base branch.

**Bug fixes**
- Windows builds were intermittently crashing at CMake-configure time because the checkout didn't fetch git tags, and x265's Windows version-string logic needs a tag present to embed into the resource file. Fixed by fetching full git history and tags during checkout.
- The Windows multilib build was uploading the wrong shared-library filename (`x265.dll` instead of the correct `libx265.dll`), so jobs that consumed that artifact couldn't find the library. Fixed the artifact path.
- macOS builds were printing Homebrew warnings about an untrusted third-party tap (`aws/tap`) on every run. Fixed by untapping it before installing dependencies.
- sccache is now pinned to v0.17.0 and downloaded directly from GitHub Releases instead of querying `api.github.com/.../releases/latest`, removing a flaky dependency on GitHub's unauthenticated API rate limit (60 req/hr, shared across all Actions runners globally).

**Smoke tests**
- `smoke-linux`/`smoke-windows` now reuse the CI's own prebuilt binaries via `smoke-test.py --no-make --no-bench` instead of having the harness rebuild from source

**AArch64 QEMU tuning**
- Trimmed the heaviest real-world test case's frame count (150 → 60) to reduce QEMU emulation time without dropping preset coverage.

**Cleanup**
- Removed unused "download multilib binary" steps from all four `test-*` jobs (binary was fetched but never invoked in any test command).
- Simplified `needs:` graphs to only what's functionally required: `smoke-*` depends on the multilib link job only (base build is covered transitively); `summary-report` depends only on the `test-*` jobs it actually consumes artifacts from.