### PR TITLE
Add CI, license, and release status badges to README

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -2,6 +2,20 @@
 x265 HEVC Encoder
 =================
 
+|ci| |license| |release|
+
+.. |ci| image:: https://img.shields.io/github/actions/workflow/status/Multicorewareinc/x265/ci.yml?branch=master&label=CI
+   :target: https://github.com/Multicorewareinc/x265/actions
+   :alt: Build Status
+
+.. |license| image:: https://img.shields.io/github/license/Multicorewareinc/x265
+   :target: https://github.com/Multicorewareinc/x265/blob/master/COPYING
+   :alt: License
+
+.. |release| image:: https://img.shields.io/github/v/release/Multicorewareinc/x265
+   :target: https://github.com/Multicorewareinc/x265/releases
+   :alt: Latest Release
+
 | **Read:** | Online `documentation <http://x265.readthedocs.org/en/master/>`_ | Developer `wiki <https://github.com/Multicorewareinc/x265/wiki/>`_
 | **Download:** | `releases <http://ftp.videolan.org/pub/videolan/x265/>`_ 
 | **Interact:** | #x265 on freenode.irc.net | `x265-devel@videolan.org <http://mailman.videolan.org/listinfo/x265-devel>`_ | `Report an issue <https://github.com/Multicorewareinc/x265/issues>`_


### PR DESCRIPTION
## Summary
Adds three status badges to the top of `README.rst`:

- **CI** – build status from the `ci.yml` GitHub Actions workflow (master branch)
- **License** – project license, linked to `COPYING`
- **Release** – latest GitHub release tag

## Changes
- Inserted `.. |ci|`, `.. |license|`, `.. |release|` image directives with links to the Actions workflow, COPYING file, and Releases page respectively
- Added the badge row (`|ci| |license| |release|`) directly under the title banner

## Testing
- Rendered `README.rst` locally to confirm badges display and link correctly
- Verified badge URLs resolve to the correct workflow/license/release pages

## Sample Image
<img width="1518" height="399" alt="Screenshot 2026-08-13 141958" src="https://github.com/user-attachments/assets/5b855068-d0bc-4b4f-9442-a0c44d95d355" />