### PR TITLE
Add TSAN+UBSAN and ASAN+UBSAN sanitizer CI jobs and migrate CI asset downloads to OneDrive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2850,31 +2850,36 @@ jobs:
   prep-assets:
     name: "Prepare Assets"
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     if: github.event_name == 'pull_request_target'
+    permissions:
+      contents: read
+      id-token: write   # required to mint the OIDC token; scoped to this job only
     steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v3.0.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true   # this app has no Azure subscription, just Graph access
+
       - name: "Download smoke assets"
+        env:
+          ONEDRIVE_USER: ${{ secrets.ONEDRIVE_USER }}
+          ONEDRIVE_FILE_PATH: ${{ secrets.ONEDRIVE_FILE_PATH }}
         run: |
-          REPO="${{ secrets.ASSETS_ORG_AND_REPO }}"
-          TAG="v4.2"
-          TOKEN="${{ secrets.ASSETS_TOKEN }}"
+          set -euo pipefail
           mkdir -p assets
+          TOKEN=$(az account get-access-token --resource https://graph.microsoft.com --query accessToken -o tsv)
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Failed to obtain Graph API token"
+            exit 1
+          fi
           download_asset() {
             local filename=$1
             echo "=== Downloading $filename ==="
-            ASSET_ID=$(curl -fsSL \
-              -H "Authorization: token $TOKEN" \
-              -H "Accept: application/vnd.github.v3+json" \
-              "https://api.github.com/repos/$REPO/releases/tags/$TAG" \
-              | python3 -c "import sys, json; data = json.load(sys.stdin); asset = next((a for a in data['assets'] if a['name'] == '$filename'), None); print(asset['id'] if asset else '')")
-            if [ -z "$ASSET_ID" ]; then
-              echo "Asset '$filename' not found in release $TAG"
-              exit 1
-            fi
-            curl -fsSL \
-              -H "Authorization: token $TOKEN" \
-              -H "Accept: application/octet-stream" \
-              "https://api.github.com/repos/$REPO/releases/assets/$ASSET_ID" \
+            curl -sfL -H "Authorization: Bearer ${TOKEN}" \
+              "https://graph.microsoft.com/v1.0/users/${ONEDRIVE_USER}/drive/root:/${ONEDRIVE_FILE_PATH}/${filename}:/content" \
               -o "assets/$filename"
             echo "[OK] $filename downloaded"
           }
@@ -2886,12 +2891,460 @@ jobs:
           download_asset "conf.tar.gz"
           download_asset "smoke-tests.tar.gz"
 
-      - name: "Upload assets artifact"
+      - name: "Upload smoke assets artifact"
         uses: actions/upload-artifact@v7
         with:
           name: smoke-assets
           path: assets/*.tar.gz
           retention-days: 1
+
+      - name: "Download sanitizer video bundle"
+        env:
+          ONEDRIVE_USER: ${{ secrets.ONEDRIVE_USER }}
+          ONEDRIVE_FILE_PATH: ${{ secrets.ONEDRIVE_FILE_PATH }}
+        run: |
+          set -euo pipefail
+          TOKEN=$(az account get-access-token --resource https://graph.microsoft.com --query accessToken -o tsv)
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Failed to obtain Graph API token"
+            exit 1
+          fi
+          echo "=== Downloading sanitizer_videos.tar.gz ==="
+          curl -sfL -H "Authorization: Bearer ${TOKEN}" \
+            "https://graph.microsoft.com/v1.0/users/${ONEDRIVE_USER}/drive/root:/${ONEDRIVE_FILE_PATH}/sanitizer_videos.tar.gz:/content" \
+            -o sanitizer_videos.tar.gz
+          echo "[OK] bundle fetched: $(du -h sanitizer_videos.tar.gz)"
+
+      - name: "Upload sanitizer video bundle artifact"
+        uses: actions/upload-artifact@v7
+        with:
+          name: sanitizer-videos-${{ github.run_id }}
+          path: sanitizer_videos.tar.gz
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
+  build-tsan:
+    name: "Build TSAN+UBSAN (${{ matrix.compiler }}, ${{ matrix.bitdepth }})"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+        bitdepth: [8bit, 10bit]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: ccache-tsan-${{ matrix.compiler }}-${{ matrix.bitdepth }}-${{ github.event.pull_request.number && format('pr{0}', github.event.pull_request.number) || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
+          restore-keys: |
+            ${{ github.event.pull_request.number && format('ccache-tsan-{0}-{1}-pr{2}-', matrix.compiler, matrix.bitdepth, github.event.pull_request.number) || '' }}
+            ccache-tsan-${{ matrix.compiler }}-${{ matrix.bitdepth }}-master-
+
+      - name: Cache apt packages
+        uses: actions/cache@v5
+        with:
+          path: /home/runner/apt-archives
+          key: apt-build-tsan-v1
+          restore-keys: apt-build-tsan-v1
+      - name: Pre-populate apt cache
+        run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq build-essential cmake nasm ccache libnuma-dev clang
+          gcc --version
+          clang --version
+
+      - name: Prepare apt cache
+        if: always()
+        run: |
+          mkdir -p /home/runner/apt-archives
+          cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
+
+      - name: Build (TSAN+UBSAN instrumented)
+        run: |
+          export PATH="/usr/lib/ccache:$PATH"
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            export CC=clang-18 CXX=clang++-18
+          else
+            export CC=gcc CXX=g++
+          fi
+          mkdir -p build/tsan && cd build/tsan
+          HBD_ARGS=""
+          if [ "${{ matrix.bitdepth }}" = "10bit" ]; then
+            HBD_ARGS="-DHIGH_BIT_DEPTH=ON"
+          fi
+          cmake ../../source \
+            -DCMAKE_C_COMPILER=$CC \
+            -DCMAKE_CXX_COMPILER=$CXX \
+            -DCMAKE_C_FLAGS="-fsanitize=thread,undefined -g -O1" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=thread,undefined -g -O1" \
+            -DENABLE_SHARED=OFF \
+            $HBD_ARGS
+          make -j$(nproc)
+          test -f x265 && echo "TSAN+UBSAN ${{ matrix.compiler }}/${{ matrix.bitdepth }} CLI binary OK"
+          ./x265 --version
+
+      - name: Verify TSAN instrumentation
+        run: |
+          # If ccache served a stale non-instrumented object set, or flags were
+          # dropped, the binary silently has no instrumentation and every test
+          # would report "Clean". Fail the build instead.
+          if nm build/tsan/x265 2>/dev/null | grep -q '__tsan_init' \
+             || strings build/tsan/x265 | grep -q 'ThreadSanitizer'; then
+            echo "[OK] Binary is TSAN-instrumented"
+          else
+            echo "::error::x265 ${{ matrix.compiler }}/${{ matrix.bitdepth }} binary is NOT TSAN-instrumented!"
+            exit 1
+          fi
+
+      - name: Upload CLI binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-tsan-${{ matrix.compiler }}-${{ matrix.bitdepth }}
+          path: build/tsan/x265
+          retention-days: 3
+
+  build-asan:
+    name: "Build ASAN+UBSAN (${{ matrix.compiler }}, ${{ matrix.bitdepth }})"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+        bitdepth: [8bit, 10bit]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: ccache-asan-${{ matrix.compiler }}-${{ matrix.bitdepth }}-${{ github.event.pull_request.number && format('pr{0}', github.event.pull_request.number) || 'master' }}-${{ github.event.pull_request.head.sha || github.sha }}
+          restore-keys: |
+            ${{ github.event.pull_request.number && format('ccache-asan-{0}-{1}-pr{2}-', matrix.compiler, matrix.bitdepth, github.event.pull_request.number) || '' }}
+            ccache-asan-${{ matrix.compiler }}-${{ matrix.bitdepth }}-master-
+
+      - name: Cache apt packages
+        uses: actions/cache@v5
+        with:
+          path: /home/runner/apt-archives
+          key: apt-build-asan-v1
+          restore-keys: apt-build-asan-v1
+      - name: Pre-populate apt cache
+        run: sudo cp /home/runner/apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq build-essential cmake nasm ccache libnuma-dev clang
+          gcc --version
+          clang --version
+
+      - name: Prepare apt cache
+        if: always()
+        run: |
+          mkdir -p /home/runner/apt-archives
+          cp -n /var/cache/apt/archives/*.deb /home/runner/apt-archives/ 2>/dev/null || true
+
+      - name: Build (ASAN+UBSAN instrumented)
+        run: |
+          export PATH="/usr/lib/ccache:$PATH"
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            export CC=clang-18 CXX=clang++-18
+          else
+            export CC=gcc CXX=g++
+          fi
+          mkdir -p build/asan && cd build/asan
+          HBD_ARGS=""
+          if [ "${{ matrix.bitdepth }}" = "10bit" ]; then
+            HBD_ARGS="-DHIGH_BIT_DEPTH=ON"
+          fi
+          cmake ../../source \
+            -DCMAKE_C_COMPILER=$CC \
+            -DCMAKE_CXX_COMPILER=$CXX \
+            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g -O1" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g -O1" \
+            -DENABLE_SHARED=OFF \
+            $HBD_ARGS
+          make -j$(nproc)
+          test -f x265 && echo "ASAN+UBSAN ${{ matrix.compiler }}/${{ matrix.bitdepth }} CLI binary OK"
+          ./x265 --version
+
+      - name: Verify ASAN instrumentation
+        run: |
+          if nm build/asan/x265 2>/dev/null | grep -q '__asan_init' \
+             || strings build/asan/x265 | grep -q 'AddressSanitizer'; then
+            echo "[OK] Binary is ASAN-instrumented"
+          else
+            echo "::error::x265 ${{ matrix.compiler }}/${{ matrix.bitdepth }} binary is NOT ASAN-instrumented!"
+            exit 1
+          fi
+
+      - name: Upload CLI binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: x265-asan-${{ matrix.compiler }}-${{ matrix.bitdepth }}
+          path: build/asan/x265
+          retention-days: 3
+
+  test-tsan:
+    name: "Test TSAN+UBSAN (${{ matrix.compiler }}, ${{ matrix.clip.label }})"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    needs: [build-tsan, prep-assets]
+    if: github.event_name == 'pull_request_target'
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+        clip:
+          - id: 8bit-ultrafast-ducks_take_off
+            label: "8bit ultrafast ducks_take_off"
+            bitdepth: 8bit
+            input: ducks_take_off_420_720p50.y4m
+            args: >-
+              --preset ultrafast --constrained-intra --rd 1 --no-info --hash=1
+              --psnr --ssim --csv /tmp/out.csv -o /tmp/out.hevc
+          - id: 8bit-medium-mobile_calendar
+            label: "8bit medium mobile_calendar"
+            bitdepth: 8bit
+            input: mobile_calendar_422_ntsc.y4m
+            args: >-
+              --preset medium --bitrate 500 -F4 --no-info --hash=1 --psnr --ssim
+              --log-level=full --csv /tmp/out.csv -o /tmp/out.hevc
+          - id: 8bit-slow-old_town_cross
+            label: "8bit slow old_town_cross"
+            bitdepth: 8bit
+            input: old_town_cross_444_720p50.y4m
+            args: >-
+              --preset slow --rdoq-level 1 --early-skip --ref 7 --no-b-pyramid
+              --no-info --hash=1 --psnr --ssim --csv /tmp/out.csv -o /tmp/out.hevc
+          - id: 8bit-veryslow-silent_cif
+            label: "8bit veryslow silent_cif"
+            bitdepth: 8bit
+            input: silent_cif_420.y4m
+            args: >-
+              --preset veryslow --me sea --no-info --hash=1 --psnr --ssim --frames 100
+              --log-level=debug --csv /tmp/out.csv -o /tmp/out.hevc
+          - id: 10bit-veryfast-RaceHorses_10bit
+            label: "10bit veryfast RaceHorses_10bit"
+            bitdepth: 10bit
+            input: RaceHorses_416x240_30_10bit.yuv
+            args: >-
+              --preset veryfast --weightb --no-info --hash=1 --psnr --ssim
+              --input-res=416x240 --input-depth=10 --input-csp=i420 --fps=30
+              --csv /tmp/out.csv -o /tmp/out.hevc
+    steps:
+      - name: Download TSAN binary
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-tsan-${{ matrix.compiler }}-${{ matrix.clip.bitdepth }}
+          path: dist
+
+      - name: Download sanitizer video bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: sanitizer-videos-${{ github.run_id }}
+
+      - name: Extract videos
+        run: |
+          mkdir -p tsan-videos
+          tar -xzf sanitizer_videos.tar.gz -C tsan-videos/
+          rm sanitizer_videos.tar.gz
+          ls -la tsan-videos/
+
+      - name: Write TSAN suppressions
+        run: |
+          cat > tsan-suppressions.txt << 'EOF'
+          # ThreadSanitizer's own internal thread-registration probe
+          # (__sanitizer::IsAccessibleMemoryRange, implemented via pipe())
+          # races against itself when x265 spins up several threads at
+          # startup (ThreadPool::start / PassEncoder::startThreads /
+          # Lookahead workers). Confirmed identical under GCC and Clang;
+          # not x265 application code, not a real data race.
+          race:IsAccessibleMemoryRange
+          EOF
+
+      - name: Run TSAN+UBSAN regression test
+        run: |
+          chmod +x dist/x265
+          X265=$(pwd)/dist/x265
+          VID=$(pwd)/tsan-videos
+          mkdir -p tsan-logs summaries
+          export TSAN_OPTIONS="halt_on_error=0:history_size=7:suppressions=$(pwd)/tsan-suppressions.txt"
+          export UBSAN_OPTIONS="halt_on_error=0:print_stacktrace=1"
+          echo "TSAN_OPTIONS=$TSAN_OPTIONS"
+          echo "UBSAN_OPTIONS=$UBSAN_OPTIONS"
+          LABEL="${{ matrix.clip.label }}"
+          LOGFILE="tsan-logs/${{ matrix.clip.id }}.log"
+          echo ""
+          echo "=== $LABEL — log: $LOGFILE ==="
+          start_ts=$SECONDS
+          $X265 ${{ matrix.clip.args }} "$VID/${{ matrix.clip.input }}" 2>&1 | tee "$LOGFILE" || true
+          rc=${PIPESTATUS[0]:-0}
+          echo "[debug] exit code: $rc | duration: $((SECONDS - start_ts))s"
+          n_tsan=$(grep -c "WARNING: ThreadSanitizer" "$LOGFILE" || true); n_tsan=${n_tsan:-0}
+          n_ubsan=$(grep -c "runtime error:" "$LOGFILE" || true); n_ubsan=${n_ubsan:-0}
+          n=$((n_tsan + n_ubsan))
+          if [ "$n" -gt 0 ]; then
+            echo "[SANITIZER] !! RESULT $LABEL: ISSUE DETECTED (tsan=$n_tsan, ubsan=$n_ubsan)"
+            grep "SUMMARY: ThreadSanitizer" "$LOGFILE" | sort | uniq -c | sort -rn || true
+            echo "| \`$LABEL\` | ISSUE DETECTED (tsan=$n_tsan, ubsan=$n_ubsan) |" > summaries/tsan-${{ matrix.compiler }}-${{ matrix.clip.id }}.log
+          else
+            echo "[SANITIZER] RESULT $LABEL: clean"
+            echo "| \`$LABEL\` | Clean |" > summaries/tsan-${{ matrix.compiler }}-${{ matrix.clip.id }}.log
+          fi
+          rm -f /tmp/out.hevc /tmp/out.csv
+          test "$n" -eq 0
+
+      - name: Upload console log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tsan-console-log-${{ matrix.compiler }}-${{ matrix.clip.id }}
+          path: tsan-logs/*.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload summary
+        uses: actions/upload-artifact@v7
+        with:
+          name: summaries-tsan-${{ matrix.compiler }}-${{ matrix.clip.id }}
+          path: summaries/*.log
+          retention-days: 3
+
+  test-asan:
+    name: "Test ASAN+UBSAN (${{ matrix.compiler }}, ${{ matrix.clip.label }})"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    needs: [build-asan, prep-assets]
+    if: github.event_name == 'pull_request_target'
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+        clip:
+          - id: 8bit-ultrafast-ducks_take_off
+            label: "8bit ultrafast ducks_take_off"
+            bitdepth: 8bit
+            input: ducks_take_off_420_720p50.y4m
+            args: >-
+              --preset ultrafast --constrained-intra --rd 1 --no-info --hash=1
+              --psnr --ssim --csv /tmp/out.csv -o /tmp/out.hevc
+          - id: 8bit-medium-mobile_calendar
+            label: "8bit medium mobile_calendar"
+            bitdepth: 8bit
+            input: mobile_calendar_422_ntsc.y4m
+            args: >-
+              --preset medium --bitrate 500 -F4 --no-info --hash=1 --psnr --ssim
+              --log-level=full --csv /tmp/out.csv -o /tmp/out.hevc
+          - id: 8bit-slow-old_town_cross
+            label: "8bit slow old_town_cross"
+            bitdepth: 8bit
+            input: old_town_cross_444_720p50.y4m
+            args: >-
+              --preset slow --rdoq-level 1 --early-skip --ref 7 --no-b-pyramid
+              --no-info --hash=1 --psnr --ssim --csv /tmp/out.csv -o /tmp/out.hevc
+          - id: 8bit-veryslow-silent_cif
+            label: "8bit veryslow silent_cif"
+            bitdepth: 8bit
+            input: silent_cif_420.y4m
+            args: >-
+              --preset veryslow --me sea --no-info --hash=1 --psnr --ssim
+              --log-level=debug --csv /tmp/out.csv -o /tmp/out.hevc
+          - id: 10bit-veryfast-RaceHorses_10bit
+            label: "10bit veryfast RaceHorses_10bit"
+            bitdepth: 10bit
+            input: RaceHorses_416x240_30_10bit.yuv
+            args: >-
+              --preset veryfast --weightb --no-info --hash=1 --psnr --ssim
+              --input-res=416x240 --input-depth=10 --input-csp=i420 --fps=30
+              --csv /tmp/out.csv -o /tmp/out.hevc
+    steps:
+      - name: Download ASAN binary
+        uses: actions/download-artifact@v8
+        with:
+          name: x265-asan-${{ matrix.compiler }}-${{ matrix.clip.bitdepth }}
+          path: dist
+
+      - name: Download sanitizer video bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: sanitizer-videos-${{ github.run_id }}
+
+      - name: Extract videos
+        run: |
+          mkdir -p asan-videos
+          tar -xzf sanitizer_videos.tar.gz -C asan-videos/
+          rm sanitizer_videos.tar.gz
+          ls -la asan-videos/
+
+      - name: Run ASAN+UBSAN regression test
+        run: |
+          chmod +x dist/x265
+          X265=$(pwd)/dist/x265
+          VID=$(pwd)/asan-videos
+          mkdir -p asan-logs summaries
+          export ASAN_OPTIONS="halt_on_error=0:detect_leaks=0"
+          export UBSAN_OPTIONS="halt_on_error=0:print_stacktrace=1"
+          echo "ASAN_OPTIONS=$ASAN_OPTIONS"
+          echo "UBSAN_OPTIONS=$UBSAN_OPTIONS"
+          LABEL="${{ matrix.clip.label }}"
+          LOGFILE="asan-logs/${{ matrix.clip.id }}.log"
+          echo ""
+          echo "=== $LABEL — log: $LOGFILE ==="
+          start_ts=$SECONDS
+          $X265 ${{ matrix.clip.args }} "$VID/${{ matrix.clip.input }}" 2>&1 | tee "$LOGFILE" || true
+          rc=${PIPESTATUS[0]:-0}
+          echo "[debug] exit code: $rc | duration: $((SECONDS - start_ts))s"
+          n_asan=$(grep -c "ERROR: AddressSanitizer\|SUMMARY: AddressSanitizer" "$LOGFILE" || true); n_asan=${n_asan:-0}
+          n_ubsan=$(grep -c "runtime error:" "$LOGFILE" || true); n_ubsan=${n_ubsan:-0}
+          n=$((n_asan + n_ubsan))
+          if [ "$n" -gt 0 ]; then
+            echo "[SANITIZER] !! RESULT $LABEL: ISSUE DETECTED (asan=$n_asan, ubsan=$n_ubsan)"
+            echo "| \`$LABEL\` | ISSUE DETECTED (asan=$n_asan, ubsan=$n_ubsan) |" > summaries/asan-${{ matrix.compiler }}-${{ matrix.clip.id }}.log
+          else
+            echo "[SANITIZER] RESULT $LABEL: clean"
+            echo "| \`$LABEL\` | Clean |" > summaries/asan-${{ matrix.compiler }}-${{ matrix.clip.id }}.log
+          fi
+          rm -f /tmp/out.hevc /tmp/out.csv
+          test "$n" -eq 0
+
+      - name: Upload console log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: asan-console-log-${{ matrix.compiler }}-${{ matrix.clip.id }}
+          path: asan-logs/*.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload summary
+        uses: actions/upload-artifact@v7
+        with:
+          name: summaries-asan-${{ matrix.compiler }}-${{ matrix.clip.id }}
+          path: summaries/*.log
+          retention-days: 3
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Smoke - Linux: reuses build-linux's already-built x265
@@ -3262,6 +3715,8 @@ jobs:
       - test-macos
       - test-aarch64
       - test-windows
+      - build-tsan
+      - build-asan
     steps:
       - name: Download all summaries
         uses: actions/download-artifact@v8
@@ -3428,6 +3883,8 @@ jobs:
       - test-macos
       - test-aarch64
       - test-windows
+      - test-tsan
+      - test-asan
     if: always() && (github.event_name == 'pull_request_target')
 
     steps:
@@ -3452,6 +3909,8 @@ jobs:
           echo "  Test macOS    : ${{ needs.test-macos.result }}"
           echo "  Test AArch64  : ${{ needs.test-aarch64.result }}"
           echo "  Test Windows  : ${{ needs.test-windows.result }}"
+          echo "  Test TSAN+UBSAN : ${{ needs.test-tsan.result }}"
+          echo "  Test ASAN+UBSAN : ${{ needs.test-asan.result }}"
           echo "================================================"
           ALL_PASS=true
           [[ "${{ needs.code-quality.result }}"    != "success" ]] && ALL_PASS=false && echo "   -> Code quality gate failed"
@@ -3467,6 +3926,8 @@ jobs:
           [[ "${{ needs.test-macos.result }}"      != "success" ]] && ALL_PASS=false && echo "   -> macOS tests failed"
           [[ "${{ needs.test-aarch64.result }}"    != "success" ]] && ALL_PASS=false && echo "   -> AArch64 tests failed"
           [[ "${{ needs.test-windows.result }}"    != "success" ]] && ALL_PASS=false && echo "   -> Windows tests failed"
+          [[ "${{ needs.test-tsan.result }}"        != "success" ]] && ALL_PASS=false && echo "   -> TSAN+UBSAN test failed - check uploaded log artifacts"
+          [[ "${{ needs.test-asan.result }}"        != "success" ]] && ALL_PASS=false && echo "   -> ASAN+UBSAN test failed - check uploaded log artifacts"
           if $ALL_PASS; then
             echo "[OK] ALL CHECKS PASSED - READY TO MERGE"
           else


### PR DESCRIPTION
## Summary
- Added TSAN+UBSAN and ASAN+UBSAN build/test jobs to catch threading and memory-safety issues before merge.
- Migrated `prep-assets` from downloading CI assets off GitHub release assets to downloading them from OneDrive (via Azure OIDC + Graph API).

## Changes

### New sanitizer jobs
- `build-tsan` / `build-asan`: build x265 with sanitizer flags across gcc/clang × 8bit/10bit, and verify the binary is actually instrumented.
- `test-tsan` / `test-asan`: run each binary against a set of test clips and fail if any sanitizer issue is detected.
- All PR-only (`if: github.event_name == 'pull_request_target'`), same as the existing smoke test jobs.
- `final-status` now includes these in its merge-gate checks.

### Asset source change
- `prep-assets` now logs in via Azure OIDC and pulls smoke-test assets and the new sanitizer video bundle from OneDrive instead of GitHub release assets.
- Added `id-token: write` permission (needed for OIDC) and bumped the job timeout to 30 min for the extra download.

## Security note
- The `id-token: write` permission and Azure credentials (`AZURE_CLIENT_ID` / `AZURE_TENANT_ID`) are scoped to the `prep-assets` job only - no other job has access to them.
- `prep-assets` does not check out any PR code, so there's no path for a malicious PR to influence this job or exfiltrate the OIDC token via untrusted code execution.