### PR TITLE
win32: ensure data symbols are correctly annotated

### DIFF
--- a/source/x265.def.in
+++ b/source/x265.def.in
@@ -9,9 +9,9 @@ x265_picture_init
 x265_picture_alloc
 x265_picture_free
 x265_param_apply_profile
-x265_max_bit_depth
-x265_version_str
-x265_build_info_str
+x265_max_bit_depth DATA
+x265_version_str DATA
+x265_build_info_str DATA
 x265_encoder_headers
 x265_encoder_parameters
 x265_encoder_reconfig


### PR DESCRIPTION
Without this, the linker may treat data symbols as functions and generate import thunks for them, which can cause crashes.

Fixes: https://github.com/strukturag/libheif/issues/357.
Additional context: https://blog.s-schoener.com/2025-06-15-windows-data-linker/.