### PR TITLE
AArch64: annotate lowres init functions as no-alias

### DIFF
--- a/source/common/common.h
+++ b/source/common/common.h
@@ -72,6 +72,7 @@
 #define NUM_INTRA_MODE 35
 
 #if defined(__GNUC__)
+#define X265_ASSUME_NO_ALIAS __restrict__
 #define ALIGN_VAR_4(T, var)  T var __attribute__((aligned(4)))
 #define ALIGN_VAR_8(T, var)  T var __attribute__((aligned(8)))
 #define ALIGN_VAR_16(T, var) T var __attribute__((aligned(16)))
@@ -83,6 +84,7 @@
 #endif
 #elif defined(_MSC_VER)
 
+#define X265_ASSUME_NO_ALIAS
 #define ALIGN_VAR_4(T, var)  __declspec(align(4)) T var
 #define ALIGN_VAR_8(T, var)  __declspec(align(8)) T var
 #define ALIGN_VAR_16(T, var) __declspec(align(16)) T var
@@ -90,6 +92,8 @@
 #define ALIGN_VAR_64(T, var) __declspec(align(64)) T var
 #define fseeko _fseeki64
 #define ftello _ftelli64
+#else
+#define X265_ASSUME_NO_ALIAS
 #endif // if defined(__GNUC__)
 #if HAVE_INT_TYPES_H
 #define __STDC_FORMAT_MACROS

--- a/source/common/lowres.cpp
+++ b/source/common/lowres.cpp
@@ -28,7 +28,9 @@
 
 namespace X265_NS {
     // forward declaration - defined in pixel.cpp, no SIMD override for MCSTF path
-    void frameInitLowresCoreMCSTF(const pixel* src0, pixel* dst0, pixel* dsth, pixel* dstv, pixel* dstc,
+    void frameInitLowresCoreMCSTF(const pixel* X265_ASSUME_NO_ALIAS src0,
+        pixel* X265_ASSUME_NO_ALIAS dst0, pixel* X265_ASSUME_NO_ALIAS dsth,
+        pixel* X265_ASSUME_NO_ALIAS dstv, pixel* X265_ASSUME_NO_ALIAS dstc,
         intptr_t src_stride, intptr_t dst_stride, int width, int height);
 }
 

--- a/source/common/pixel.cpp
+++ b/source/common/pixel.cpp
@@ -594,7 +594,9 @@ static void scale2D_64to32(pixel* dst, const pixel* src, intptr_t stride)
 }
 
 static
-void frame_init_lowres_core(const pixel* src0, pixel* dst0, pixel* dsth, pixel* dstv, pixel* dstc,
+void frame_init_lowres_core(const pixel* X265_ASSUME_NO_ALIAS src0, pixel* X265_ASSUME_NO_ALIAS dst0,
+                            pixel* X265_ASSUME_NO_ALIAS dsth, pixel* X265_ASSUME_NO_ALIAS dstv,
+                            pixel* X265_ASSUME_NO_ALIAS dstc,
                             intptr_t src_stride, intptr_t dst_stride, int width, int height)
 {
     for (int y = 0; y < height; y++)
@@ -1014,7 +1016,9 @@ namespace X265_NS {
 // x265 private namespace
 
 /* Scalar lowres downscale for MCSTF path - HM-equivalent filter, no SIMD override */
-    void frameInitLowresCoreMCSTF(const pixel* src0, pixel* dst0, pixel* dsth, pixel* dstv, pixel* dstc,
+    void frameInitLowresCoreMCSTF(const pixel* X265_ASSUME_NO_ALIAS src0,
+        pixel* X265_ASSUME_NO_ALIAS dst0, pixel* X265_ASSUME_NO_ALIAS dsth,
+        pixel* X265_ASSUME_NO_ALIAS dstv, pixel* X265_ASSUME_NO_ALIAS dstc,
         intptr_t src_stride, intptr_t dst_stride, int width, int height)
     {
         for (int y = 0; y < height; y++)

--- a/source/test/pixelharness.cpp
+++ b/source/test/pixelharness.cpp
@@ -77,6 +77,7 @@ PixelHarness::PixelHarness()
         pbuf2[i] = rand() & PIXEL_MAX;
         pbuf3[i] = rand() & PIXEL_MAX;
         pbuf4[i] = rand() & PIXEL_MAX;
+        pbuf5[i] = rand() & PIXEL_MAX;
 
         sbuf1[i] = (rand() % (2 * SMAX + 1)) - SMAX - 1; //max(SHORT_MIN, min(rand(), SMAX));
         sbuf2[i] = (rand() % (2 * SMAX + 1)) - SMAX - 1; //max(SHORT_MIN, min(rand(), SMAX));
@@ -3566,7 +3567,7 @@ void PixelHarness::measureSpeed(const EncoderPrimitives& ref, const EncoderPrimi
     if (opt.frameInitLowres)
     {
         HEADER0("downscale");
-        REPORT_SPEEDUP(opt.frameInitLowres, ref.frameInitLowres, pbuf2, pbuf1, pbuf2, pbuf3, pbuf4, 64, 64, 64, 64);
+        REPORT_SPEEDUP(opt.frameInitLowres, ref.frameInitLowres, pbuf1, pbuf2, pbuf3, pbuf4, pbuf5, 64, 64, 64, 64);
     }
 
     if (opt.scale1D_128to64[NONALIGNED])

--- a/source/test/pixelharness.h
+++ b/source/test/pixelharness.h
@@ -48,6 +48,7 @@ protected:
     ALIGN_VAR_64(pixel,    pbuf2[BUFFSIZE]);
     ALIGN_VAR_64(pixel,    pbuf3[BUFFSIZE]);
     ALIGN_VAR_64(pixel,    pbuf4[BUFFSIZE]);
+    ALIGN_VAR_64(pixel,    pbuf5[BUFFSIZE]);
     ALIGN_VAR_64(int,      ibuf1[BUFFSIZE]);
     ALIGN_VAR_64(int8_t,   psbuf1[BUFFSIZE]);
     ALIGN_VAR_64(int8_t,   psbuf2[BUFFSIZE]);


### PR DESCRIPTION
Add X265_ASSUME_NO_ALIAS and apply it to frame_init_lowres_core and frameInitLowresCoreMCSTF. This lets GCC vectorize the lowres initialization loops, making them up to 7x faster and generating code equivalent to Clang.