### PR TITLE
CLI: Fix null pointer dereference without arguments

### DIFF
--- a/source/x265cli.cpp
+++ b/source/x265cli.cpp
@@ -489,7 +489,7 @@ namespace X265_NS {
             output->release();
         output = NULL;
 
-        if (param->foveaGazeFile)
+        if (param && param->foveaGazeFile)
             free(param->foveaGazeFile);
 
         if (param && api)


### PR DESCRIPTION
Prevent foveaGazeFile incorrect access when the CLI parameters are not initialized. This prevents a null pointer dereference when invoking the CLI with no arguments.