### PR TITLE
RISCV64/AArch64: Fix stack-buffer-underflow in intraFilter_rvv/intraFilter_neon

### DIFF
--- a/source/common/aarch64/intrapred-prim.cpp
+++ b/source/common/aarch64/intrapred-prim.cpp
@@ -22,7 +22,20 @@ void intraFilter_neon(const pixel* samples, pixel* filtered) /* 1:2:1 filtering 
     uint16x8_t two_vec = vdupq_n_u16(2);
 #if !HIGH_BIT_DEPTH
     {
-        for(int i = 0; i < tuSize2 + tuSize2; i+=8)
+        // Avoid reading samples[-1]. build it from the loaded sample1 instead.
+        // The first value is unused since filtered[0] is overwritten below anyway.
+        {
+            uint8x8_t raw1 = vld1_u8(&samples[0]);
+            uint16x8_t sample1 = vmovl_u8(raw1);
+            uint16x8_t sample2 = vmovl_u8(vext_u8(raw1, raw1, 7));
+            uint16x8_t sample3 = vmovl_u8(vld1_u8(&samples[1]));
+
+            uint16x8_t result1 = vaddq_u16(vshlq_n_u16(sample1,1), sample2 );
+            uint16x8_t result2 = vaddq_u16(sample3, two_vec);
+            uint16x8_t result3 = vaddq_u16(result1,result2);
+            vst1_u8(&filtered[0] , vmovn_u16(vshrq_n_u16(result3, 2)));
+        }
+        for(int i = 8; i < tuSize2 + tuSize2; i+=8)
          {
             uint16x8_t sample1 = vmovl_u8(vld1_u8(&samples[i]));
             uint16x8_t sample2 = vmovl_u8(vld1_u8(&samples[i-1]));
@@ -36,7 +49,17 @@ void intraFilter_neon(const pixel* samples, pixel* filtered) /* 1:2:1 filtering 
     }
 #else
     {
-        for(int i = 0; i < tuSize2 + tuSize2; i+=8)
+        {
+            uint16x8_t sample1 = vld1q_u16(&samples[0]);
+            uint16x8_t sample2 = vextq_u16(sample1, sample1, 7);
+            uint16x8_t sample3 = vld1q_u16(&samples[1]);
+
+            uint16x8_t result1 = vaddq_u16(vshlq_n_u16(sample1,1), sample2 );
+            uint16x8_t result2 = vaddq_u16(sample3, two_vec);
+            uint16x8_t result3 = vaddq_u16(result1,result2);
+            vst1q_u16(&filtered[0] , vshrq_n_u16(result3, 2));
+        }
+        for(int i = 8; i < tuSize2 + tuSize2; i+=8)
         {
             uint16x8_t sample1 = vld1q_u16(&samples[i]);
             uint16x8_t sample2 = vld1q_u16(&samples[i-1]);

--- a/source/common/riscv64/intrapred-prim.cpp
+++ b/source/common/riscv64/intrapred-prim.cpp
@@ -44,7 +44,30 @@ void intraFilter_rvv(const pixel* samples, pixel* filtered) /* 1:2:1 filtering o
     {
         size_t vl = __riscv_vsetvl_e16m2(len);
         vuint16m2_t two_vec = __riscv_vmv_v_x_u16m2(2, vl);
-        for(int i = 0; i < len; i+=vl) {
+
+        size_t vl0 = __riscv_vsetvl_e8m1(len);
+        {
+            vuint8m1_t sample1_u8 = __riscv_vle8_v_u8m1(&samples[0], vl0);
+            vuint8m1_t sample2_u8 = __riscv_vslide1up_vx_u8m1(sample1_u8, samples[0], vl0);
+            vuint8m1_t sample3_u8 = __riscv_vle8_v_u8m1(&samples[1], vl0);
+
+            vuint16m2_t sample1 = __riscv_vzext_vf2_u16m2(sample1_u8, vl0);
+            vuint16m2_t sample2 = __riscv_vzext_vf2_u16m2(sample2_u8, vl0);
+            vuint16m2_t sample3 = __riscv_vzext_vf2_u16m2(sample3_u8, vl0);
+
+            vuint16m2_t result1 = __riscv_vsll_vx_u16m2(sample1, 1, vl0);
+            result1 = __riscv_vadd_vv_u16m2(result1, sample2, vl0);
+            vuint16m2_t result2 = __riscv_vadd_vv_u16m2(sample3, two_vec, vl0);
+            vuint16m2_t result3 = __riscv_vadd_vv_u16m2(result1, result2, vl0);
+            result3 = __riscv_vsrl_vx_u16m2(result3, 2, vl0);
+
+            vuint8m1_t result_u8 = __riscv_vnsrl_wx_u8m1(result3, 0, vl0);
+            __riscv_vse8_v_u8m1(&filtered[0], result_u8, vl0);
+        }
+
+        // Original loop, unchanged, just starting after the block we
+        // already handled above instead of from i=0.
+        for (int i = (int)vl0; i < len; i += vl) {
             vl = __riscv_vsetvl_e8m1(len - i);
             vuint8m1_t sample1_u8 = __riscv_vle8_v_u8m1(&samples[i], vl);
             vuint8m1_t sample2_u8 = __riscv_vle8_v_u8m1(&samples[i-1], vl);
@@ -68,7 +91,22 @@ void intraFilter_rvv(const pixel* samples, pixel* filtered) /* 1:2:1 filtering o
     {
         size_t vl = __riscv_vsetvl_e16m1(len);
         vuint16m1_t two_vec = __riscv_vmv_v_x_u16m1(2, vl);
-        for(int i = 0; i < len; i += vl) {
+
+        size_t vl0 = __riscv_vsetvl_e16m1(len);
+        {
+            vuint16m1_t sample1 = __riscv_vle16_v_u16m1(&samples[0], vl0);
+            vuint16m1_t sample2 = __riscv_vslide1up_vx_u16m1(sample1, samples[0], vl0);
+            vuint16m1_t sample3 = __riscv_vle16_v_u16m1(&samples[1], vl0);
+
+            vuint16m1_t result1 = __riscv_vsll_vx_u16m1(sample1, 1, vl0);
+            result1 = __riscv_vadd_vv_u16m1(result1, sample2, vl0);
+            vuint16m1_t result2 = __riscv_vadd_vv_u16m1(sample3, two_vec, vl0);
+            vuint16m1_t result3 = __riscv_vadd_vv_u16m1(result1, result2, vl0);
+            result3 = __riscv_vsrl_vx_u16m1(result3, 2, vl0);
+            __riscv_vse16_v_u16m1(&filtered[0], result3, vl0);
+        }
+
+        for (int i = (int)vl0; i < len; i += vl) {
             vl = __riscv_vsetvl_e16m1(len - i);
             vuint16m1_t sample1 = __riscv_vle16_v_u16m1(&samples[i], vl);
             vuint16m1_t sample2 = __riscv_vle16_v_u16m1(&samples[i-1], vl);


### PR DESCRIPTION
## Summary
Fixes #940 - a stack-buffer-underflow in `intraFilter_neon`, reported by AddressSanitizer on arm64. The same underflow pattern exists in the riscv, `intraFilter_rvv` (noted in the issue discussion), and is fixed here too.
 
## Issue
Both functions loop over sample data in fixed width vector chunks and read `samples[i - 1]`:
```c
for (int i = 0; i < len; i += vl) {
    sample2 = load(&samples[i - 1]);   // underflows when i == 0
    ...
}
```
At `i = 0` this reads `samples[-1]`, one byte before the start of the buffer - the root cause of the ASan crash reported in #940.
 
## Fix
- The first vector chunk (`i == 0`) is handled separately, instead of going through the main loop.
- Instead of reading `samples[-1]`, the "previous sample" is synthesized in-register by rotating the samples already loaded, using each ISA's native lane-rotate instruction:
  - **NEON**: `vext_u8` / `vextq_u16`
  - **RVV**: `__riscv_vslide1up_vx_*`
- The main loop's index sequence is otherwise unchanged - it now simply starts after this first chunk instead of from `i = 0`.
- The synthesized value for position 0 is discarded anyway, since `filtered[0]` is always overwritten elsewhere in the existing code.