### PR TITLE
rdoq: Reduce redundant coefficient processing

### DIFF
--- a/source/common/common.h
+++ b/source/common/common.h
@@ -229,7 +229,7 @@ typedef int16_t  coeff_t;      // transform coefficient
 #define X265_LOWRES_CU_SIZE   8
 #define X265_LOWRES_CU_BITS   3
 
-#define X265_MALLOC(type, count)    (type*)x265_malloc(sizeof(type) * (count))
+#define X265_MALLOC(type, count)    static_cast<type*>(x265_malloc(sizeof(type) * (count)))
 #define X265_FREE(ptr)              x265_free(ptr)
 #define X265_FREE_ZERO(ptr)         { x265_free(ptr); (ptr) = NULL; }
 #define CHECKED_MALLOC(var, type, count) \

--- a/source/common/dct.cpp
+++ b/source/common/dct.cpp
@@ -1077,13 +1077,15 @@ static void nonPsyRdoQuantAll_c(const int16_t *resiDctCoeff, int64_t *costUncode
     const int scaleBits = SCALE_BITS - 2 * transformShift;
     const int numCoeff = 1 << (2 * log2TrSize);
 
+    int64_t totalCost = 0;
     for (int blkPos = 0; blkPos < numCoeff; blkPos++)
     {
         int64_t signCoef = resiDctCoeff[blkPos];
         costUncoded[blkPos] = static_cast<int64_t>((double)((signCoef * signCoef) << scaleBits));
-        *totalUncodedCost += costUncoded[blkPos];
-        *totalRdCost += costUncoded[blkPos];
+        totalCost += costUncoded[blkPos];
     }
+    *totalUncodedCost += totalCost;
+    *totalRdCost += totalCost;
 }
 
 template<int log2TrSize>
@@ -1094,15 +1096,18 @@ static void psyRdoQuantAll_c(const int16_t *resiDctCoeff, const int16_t *fencDct
     const int psyShift = X265_MAX(0, 2 * transformShift + 1);
     const int numCoeff = 1 << (2 * log2TrSize);
 
+    const int64_t scale = *psyScale;
+    int64_t totalCost = 0;
     for (int blkPos = 0; blkPos < numCoeff; blkPos++)
     {
         int64_t signCoef = resiDctCoeff[blkPos];
         int64_t predictedCoef = fencDctCoeff[blkPos] - signCoef;
         costUncoded[blkPos] = static_cast<int64_t>((double)((signCoef * signCoef) << scaleBits));
-        costUncoded[blkPos] -= static_cast<int64_t>((double)((*psyScale * predictedCoef) >> psyShift));
-        *totalUncodedCost += costUncoded[blkPos];
-        *totalRdCost += costUncoded[blkPos];
+        costUncoded[blkPos] -= static_cast<int64_t>((double)((scale * predictedCoef) >> psyShift));
+        totalCost += costUncoded[blkPos];
     }
+    *totalUncodedCost += totalCost;
+    *totalRdCost += totalCost;
 }
 
 namespace X265_NS {

--- a/source/common/dct.cpp
+++ b/source/common/dct.cpp
@@ -1070,6 +1070,41 @@ static void psyRdoQuant_c_2(int16_t *m_resiDctCoeff, int16_t *m_fencDctCoeff, in
 	}
 }
 
+template<int log2TrSize>
+static void nonPsyRdoQuantAll_c(int16_t *resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost)
+{
+    const int transformShift = MAX_TR_DYNAMIC_RANGE - X265_DEPTH - log2TrSize;
+    const int scaleBits = SCALE_BITS - 2 * transformShift;
+    const int numCoeff = 1 << (2 * log2TrSize);
+
+    for (int blkPos = 0; blkPos < numCoeff; blkPos++)
+    {
+        int64_t signCoef = resiDctCoeff[blkPos];
+        costUncoded[blkPos] = static_cast<int64_t>((double)((signCoef * signCoef) << scaleBits));
+        *totalUncodedCost += costUncoded[blkPos];
+        *totalRdCost += costUncoded[blkPos];
+    }
+}
+
+template<int log2TrSize>
+static void psyRdoQuantAll_c(int16_t *resiDctCoeff, int16_t *fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, int64_t *psyScale)
+{
+    const int transformShift = MAX_TR_DYNAMIC_RANGE - X265_DEPTH - log2TrSize;
+    const int scaleBits = SCALE_BITS - 2 * transformShift;
+    const int psyShift = X265_MAX(0, 2 * transformShift + 1);
+    const int numCoeff = 1 << (2 * log2TrSize);
+
+    for (int blkPos = 0; blkPos < numCoeff; blkPos++)
+    {
+        int64_t signCoef = resiDctCoeff[blkPos];
+        int64_t predictedCoef = fencDctCoeff[blkPos] - signCoef;
+        costUncoded[blkPos] = static_cast<int64_t>((double)((signCoef * signCoef) << scaleBits));
+        costUncoded[blkPos] -= static_cast<int64_t>((double)((*psyScale * predictedCoef) >> psyShift));
+        *totalUncodedCost += costUncoded[blkPos];
+        *totalRdCost += costUncoded[blkPos];
+    }
+}
+
 namespace X265_NS {
 // x265 private namespace
 void setupDCTPrimitives_c(EncoderPrimitives& p)
@@ -1086,6 +1121,14 @@ void setupDCTPrimitives_c(EncoderPrimitives& p)
     p.cu[BLOCK_8x8].psyRdoQuant = psyRdoQuant_c<3>;
     p.cu[BLOCK_16x16].psyRdoQuant = psyRdoQuant_c<4>;
     p.cu[BLOCK_32x32].psyRdoQuant = psyRdoQuant_c<5>;
+    p.cu[BLOCK_4x4].nonPsyRdoQuantAll = nonPsyRdoQuantAll_c<2>;
+    p.cu[BLOCK_8x8].nonPsyRdoQuantAll = nonPsyRdoQuantAll_c<3>;
+    p.cu[BLOCK_16x16].nonPsyRdoQuantAll = nonPsyRdoQuantAll_c<4>;
+    p.cu[BLOCK_32x32].nonPsyRdoQuantAll = nonPsyRdoQuantAll_c<5>;
+    p.cu[BLOCK_4x4].psyRdoQuantAll = psyRdoQuantAll_c<2>;
+    p.cu[BLOCK_8x8].psyRdoQuantAll = psyRdoQuantAll_c<3>;
+    p.cu[BLOCK_16x16].psyRdoQuantAll = psyRdoQuantAll_c<4>;
+    p.cu[BLOCK_32x32].psyRdoQuantAll = psyRdoQuantAll_c<5>;
     p.dst4x4 = dst4_c;
     p.cu[BLOCK_4x4].dct   = dct4_c;
     p.cu[BLOCK_8x8].dct   = dct8_c;

--- a/source/common/dct.cpp
+++ b/source/common/dct.cpp
@@ -1071,7 +1071,7 @@ static void psyRdoQuant_c_2(int16_t *m_resiDctCoeff, int16_t *m_fencDctCoeff, in
 }
 
 template<int log2TrSize>
-static void nonPsyRdoQuantAll_c(int16_t *resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost)
+static void nonPsyRdoQuantAll_c(const int16_t *resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost)
 {
     const int transformShift = MAX_TR_DYNAMIC_RANGE - X265_DEPTH - log2TrSize;
     const int scaleBits = SCALE_BITS - 2 * transformShift;
@@ -1087,7 +1087,7 @@ static void nonPsyRdoQuantAll_c(int16_t *resiDctCoeff, int64_t *costUncoded, int
 }
 
 template<int log2TrSize>
-static void psyRdoQuantAll_c(int16_t *resiDctCoeff, int16_t *fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, int64_t *psyScale)
+static void psyRdoQuantAll_c(const int16_t *resiDctCoeff, const int16_t *fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, const int64_t *psyScale)
 {
     const int transformShift = MAX_TR_DYNAMIC_RANGE - X265_DEPTH - log2TrSize;
     const int scaleBits = SCALE_BITS - 2 * transformShift;

--- a/source/common/primitives.h
+++ b/source/common/primitives.h
@@ -230,8 +230,8 @@ typedef void(*nonPsyRdoQuant_t)(int16_t *m_resiDctCoeff, int64_t *costUncoded, i
 typedef void(*psyRdoQuant_t)(int16_t *m_resiDctCoeff, int16_t *m_fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, int64_t *psyScale, uint32_t blkPos);
 typedef void(*psyRdoQuant_t1)(int16_t *m_resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost,uint32_t blkPos);
 typedef void(*psyRdoQuant_t2)(int16_t *m_resiDctCoeff, int16_t *m_fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, int64_t *psyScale, uint32_t blkPos);
-typedef void(*nonPsyRdoQuantAll_t)(int16_t *m_resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost);
-typedef void(*psyRdoQuantAll_t)(int16_t *m_resiDctCoeff, int16_t *m_fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, int64_t *psyScale);
+typedef void(*nonPsyRdoQuantAll_t)(const int16_t *m_resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost);
+typedef void(*psyRdoQuantAll_t)(const int16_t *m_resiDctCoeff, const int16_t *m_fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, const int64_t *psyScale);
 typedef void(*ssimDistortion_t)(const pixel *fenc, uint32_t fStride, const pixel *recon,  intptr_t rstride, uint64_t *ssBlock, int shift, uint64_t *ac_k);
 typedef void(*normFactor_t)(const pixel *src, uint32_t blockSize, int shift, uint64_t *z_k);
 /* SubSampling Luma */

--- a/source/common/primitives.h
+++ b/source/common/primitives.h
@@ -230,6 +230,8 @@ typedef void(*nonPsyRdoQuant_t)(int16_t *m_resiDctCoeff, int64_t *costUncoded, i
 typedef void(*psyRdoQuant_t)(int16_t *m_resiDctCoeff, int16_t *m_fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, int64_t *psyScale, uint32_t blkPos);
 typedef void(*psyRdoQuant_t1)(int16_t *m_resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost,uint32_t blkPos);
 typedef void(*psyRdoQuant_t2)(int16_t *m_resiDctCoeff, int16_t *m_fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, int64_t *psyScale, uint32_t blkPos);
+typedef void(*nonPsyRdoQuantAll_t)(int16_t *m_resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost);
+typedef void(*psyRdoQuantAll_t)(int16_t *m_resiDctCoeff, int16_t *m_fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, int64_t *psyScale);
 typedef void(*ssimDistortion_t)(const pixel *fenc, uint32_t fStride, const pixel *recon,  intptr_t rstride, uint64_t *ssBlock, int shift, uint64_t *ac_k);
 typedef void(*normFactor_t)(const pixel *src, uint32_t blockSize, int shift, uint64_t *z_k);
 /* SubSampling Luma */
@@ -308,8 +310,10 @@ struct EncoderPrimitives
         intra_pred_t    intra_pred[NUM_INTRA_MODE];
         nonPsyRdoQuant_t nonPsyRdoQuant;
         psyRdoQuant_t    psyRdoQuant;
-		psyRdoQuant_t1   psyRdoQuant_1p;
-		psyRdoQuant_t2   psyRdoQuant_2p;
+        psyRdoQuant_t1   psyRdoQuant_1p;
+        psyRdoQuant_t2   psyRdoQuant_2p;
+        nonPsyRdoQuantAll_t nonPsyRdoQuantAll;
+        psyRdoQuantAll_t psyRdoQuantAll;
         ssimDistortion_t ssimDist;
         normFactor_t     normFact;
     }

--- a/source/common/quant.cpp
+++ b/source/common/quant.cpp
@@ -177,7 +177,6 @@ Quant::rdoQuant_t Quant::rdoQuant_func[NUM_CU_DEPTH] = {&Quant::rdoQuant<2>, &Qu
 Quant::Quant()
 {
     m_resiDctCoeff = NULL;
-    m_fencDctCoeff = NULL;
     m_fencShortBuf = NULL;
     m_frameNr      = NULL;
     m_nr           = NULL;
@@ -189,11 +188,24 @@ bool Quant::init(double psyScale, const ScalingList& scalingList, Entropy& entro
     m_psyRdoqScale = (int32_t)(psyScale * 256.0);
     X265_CHECK((psyScale * 256.0) < (double)MAX_INT, "psyScale value too large\n");
     m_scalingList  = &scalingList;
-    m_resiDctCoeff = X265_MALLOC(int16_t, MAX_TR_SIZE * MAX_TR_SIZE * 2);
-    m_fencDctCoeff = m_resiDctCoeff + (MAX_TR_SIZE * MAX_TR_SIZE);
-    m_fencShortBuf = X265_MALLOC(int16_t, MAX_TR_SIZE * MAX_TR_SIZE);
+    m_resiDctCoeff = X265_MALLOC(int16_t, MAX_TR_SIZE * MAX_TR_SIZE + SOURCE_DCT_COEFFS);
+    m_fencShortBuf = X265_MALLOC(int16_t, SOURCE_DCT_COEFFS);
 
-    return m_resiDctCoeff && m_fencShortBuf;
+    if (!m_resiDctCoeff || !m_fencShortBuf)
+        return false;
+
+    /* Store larger transforms first to keep every cache buffer aligned. */
+    int16_t* coeff = m_resiDctCoeff + MAX_TR_SIZE * MAX_TR_SIZE;
+    int16_t* pixels = m_fencShortBuf;
+    for (int sizeIdx = NUM_TR_SIZE - 1; sizeIdx >= 0; sizeIdx--)
+    {
+        const int numCoeff = 1 << (2 * (sizeIdx + 2));
+        m_sourceDctCache[sizeIdx].coeff = coeff;
+        m_sourceDctCache[sizeIdx].pixels = pixels;
+        coeff += numCoeff;
+        pixels += numCoeff;
+    }
+    return true;
 }
 
 bool Quant::allocNoiseReduction(const x265_param& param)
@@ -613,26 +625,27 @@ uint32_t Quant::rdoQuant(const CUData &cu, int16_t *dstCoeff, TextType ttype, ui
     if (!numSig)
         return 0;
     const uint32_t trSize = 1 << log2TrSize;
+    SourceDctCache& sourceCache = m_sourceDctCache[log2TrSize - 2];
+    int16_t* const sourceDct = sourceCache.coeff;
+    int16_t* const sourcePixels = sourceCache.pixels;
     if (usePsy)
     {
         /* Prediction candidates share the source transform for the same image block. */
         const uint32_t sourcePartIdx = cu.m_absIdxInCTU + absPartIdx;
-        if (m_sourceDctCache.slice != cu.m_slice || m_sourceDctCache.poc != cu.m_slice->m_poc ||
-            m_sourceDctCache.log2Size != log2TrSize || m_sourceDctCache.cuAddr != cu.m_cuAddr ||
-            m_sourceDctCache.absPartIdx != sourcePartIdx)
+        if (sourceCache.slice != cu.m_slice || sourceCache.poc != cu.m_slice->m_poc ||
+            sourceCache.cuAddr != cu.m_cuAddr || sourceCache.absPartIdx != sourcePartIdx)
         {
-            primitives.cu[log2TrSize - 2].copy_ps(m_fencShortBuf, trSize, fenc, fencStride);
-            primitives.cu[log2TrSize - 2].dct(m_fencShortBuf, m_fencDctCoeff, trSize);
-            m_sourceDctCache.slice = cu.m_slice;
-            m_sourceDctCache.poc = cu.m_slice->m_poc;
-            m_sourceDctCache.log2Size = log2TrSize;
-            m_sourceDctCache.cuAddr = cu.m_cuAddr;
-            m_sourceDctCache.absPartIdx = sourcePartIdx;
+            primitives.cu[log2TrSize - 2].copy_ps(sourcePixels, trSize, fenc, fencStride);
+            primitives.cu[log2TrSize - 2].dct(sourcePixels, sourceDct, trSize);
+            sourceCache.slice = cu.m_slice;
+            sourceCache.poc = cu.m_slice->m_poc;
+            sourceCache.cuAddr = cu.m_cuAddr;
+            sourceCache.absPartIdx = sourcePartIdx;
         }
 #if CHECKED_BUILD || _DEBUG
         for (uint32_t y = 0; y < trSize; y++)
             for (uint32_t x = 0; x < trSize; x++)
-                X265_CHECK(fenc[y * fencStride + x] == m_fencShortBuf[y * trSize + x], "source DCT cache mismatch\n");
+                X265_CHECK(fenc[y * fencStride + x] == sourcePixels[y * trSize + x], "source DCT cache mismatch\n");
 #endif
     }
 
@@ -708,10 +721,10 @@ uint32_t Quant::rdoQuant(const CUData &cu, int16_t *dstCoeff, TextType ttype, ui
      * coefficient loop replace uncoded costs with coded costs as needed. */
     if (usePsyMask)
     {
-        primitives.cu[log2TrSize - 2].psyRdoQuantAll(m_resiDctCoeff, m_fencDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, &psyScale);
+        primitives.cu[log2TrSize - 2].psyRdoQuantAll(m_resiDctCoeff, sourceDct, costUncoded, &totalUncodedCost, &totalRdCost, &psyScale);
 
         /* DC distortion does not include the psy-RDOQ reconstruction bias. */
-        int64_t dcPsyCost = PSYVALUE(m_fencDctCoeff[0] - m_resiDctCoeff[0]);
+        int64_t dcPsyCost = PSYVALUE(sourceDct[0] - m_resiDctCoeff[0]);
         costUncoded[0] += dcPsyCost;
         totalUncodedCost += dcPsyCost;
         totalRdCost += dcPsyCost;
@@ -761,7 +774,7 @@ uint32_t Quant::rdoQuant(const CUData &cu, int16_t *dstCoeff, TextType ttype, ui
             uint32_t blkPos      = scan[scanPos];
             uint32_t maxAbsLevel = dstCoeff[blkPos];                  /* abs(quantized coeff) */
             int signCoef         = m_resiDctCoeff[blkPos];            /* pre-quantization DCT coeff */
-            int predictedCoef    = m_fencDctCoeff[blkPos] - signCoef; /* predicted DCT = source DCT - residual DCT*/
+            int predictedCoef    = sourceDct[blkPos] - signCoef; /* predicted DCT = source DCT - residual DCT*/
             int64_t uncodedCost = costUncoded[blkPos];
 
             // coefficient level estimation

--- a/source/common/quant.cpp
+++ b/source/common/quant.cpp
@@ -46,11 +46,6 @@ struct coeffGroupRDStats
     int64_t sigCost0;          /* cost of signaling sig coeff bit of coeff 0 */
 };
 
-inline int fastMin(int x, int y)
-{
-    return y + ((x - y) & ((x - y) >> (sizeof(int) * CHAR_BIT - 1))); // min(x, y)
-}
-
 inline int getICRate(uint32_t absLevel, int32_t diffLevel, const int* greaterOneBits, const int* levelAbsBits, const uint32_t absGoRice, const uint32_t maxVlc, const uint32_t c1c2Rate)
 {
     X265_CHECK(absGoRice <= 4, "absGoRice check failure\n");
@@ -86,12 +81,12 @@ inline int getICRate(uint32_t absLevel, int32_t diffLevel, const int* greaterOne
             rate += egs << 15;
 
             // NOTE: in here, expGolomb=true means (symbol >= maxVlc + 1)
-            X265_CHECK(fastMin(symbol, (maxVlc + 1)) == (int)maxVlc + 1, "min check failure\n");
+            X265_CHECK(X265_MIN(symbol, (maxVlc + 1)) == (int)maxVlc + 1, "min check failure\n");
             symbol = maxVlc + 1;
         }
 
         uint32_t prefLen = (symbol >> absGoRice) + 1;
-        uint32_t numBins = fastMin(prefLen + absGoRice, 8 /* g_goRicePrefixLen[absGoRice] + absGoRice */);
+        uint32_t numBins = X265_MIN(prefLen + absGoRice, 8 /* g_goRicePrefixLen[absGoRice] + absGoRice */);
 
         rate += numBins << 15;
         rate += c1c2Rate;
@@ -127,7 +122,7 @@ inline int getICRateLessVlc(uint32_t absLevel, int32_t diffLevel, const uint32_t
 
     uint32_t symbol = diffLevel;
     uint32_t prefLen = (symbol >> absGoRice) + 1;
-    uint32_t numBins = fastMin(prefLen + absGoRice, 8 /* g_goRicePrefixLen[absGoRice] + absGoRice */);
+    uint32_t numBins = X265_MIN(prefLen + absGoRice, 8 /* g_goRicePrefixLen[absGoRice] + absGoRice */);
 
     rate = numBins << 15;
 
@@ -673,7 +668,6 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
     const ScanType scanType = codeParams.scanType;
     const uint32_t firstSignificanceMapContext = codeParams.firstSignificanceMapContext;
     const uint32_t log2TrSizeCG = log2TrSize - 2;
-    const uint32_t cgNum = 1 << (log2TrSizeCG * 2);
     const uint32_t cgStride = (trSize >> MLS_CG_LOG2_SIZE);
 
     uint8_t coeffNum[MLS_GRP_NUM];      // value range[0, 16]
@@ -695,13 +689,6 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
 
     uint32_t scanPos = 0;
     uint32_t c1 = 1;
-
-    // process trail all zero Coeff Group
-
-    /* coefficients after lastNZ have no distortion signal cost */
-    const int zeroCG = cgNum - 1 - cgLastScanPos;
-    memset(&costCoeff[(cgLastScanPos + 1) << MLS_CG_SIZE], 0, zeroCG * MLS_CG_BLK_SIZE * sizeof(int64_t));
-    memset(&costSig[(cgLastScanPos + 1) << MLS_CG_SIZE], 0, zeroCG * MLS_CG_BLK_SIZE * sizeof(int64_t));
 
     /* Initialize the uncoded distortion for every coefficient. This lets the
      * coefficient loop replace uncoded costs with coded costs as needed. */
@@ -753,7 +740,8 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
         uint32_t c1Idx       = 0;
         uint32_t c2Idx       = 0;
         /* iterate over coefficients in each group in reverse scan order */
-        for (int scanPosinCG = cgSize - 1; scanPosinCG >= 0; scanPosinCG--)
+        const int lastScanPosinCG = X265_MIN(lastScanPos - (cgScanPos << MLS_CG_SIZE), (int)cgSize - 1);
+        for (int scanPosinCG = lastScanPosinCG; scanPosinCG >= 0; scanPosinCG--)
         {
             scanPos              = (cgScanPos << MLS_CG_SIZE) + scanPosinCG;
             uint32_t blkPos      = scan[scanPos];
@@ -761,15 +749,6 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
             int signCoef         = m_resiDctCoeff[blkPos];            /* pre-quantization DCT coeff */
             int predictedCoef    = m_fencDctCoeff[blkPos] - signCoef; /* predicted DCT = source DCT - residual DCT*/
             int64_t uncodedCost = costUncoded[blkPos];
-
-            if (scanPos > (uint32_t)lastScanPos)
-            {
-                /* coefficients after lastNZ have no distortion signal cost */
-                costCoeff[scanPos] = 0;
-                costSig[scanPos] = 0;
-
-                continue;
-            }
 
             // coefficient level estimation
             const int* greaterOneBits = estBitsSbac.greaterOneBits[4 * ctxSet + c1];
@@ -1074,11 +1053,10 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
             continue;
         }
 
-        for (int scanPosinCG = cgSize - 1; scanPosinCG >= 0; scanPosinCG--)
+        const int lastScanPosinCG = X265_MIN(lastScanPos - (cgScanPos << MLS_CG_SIZE), (int)cgSize - 1);
+        for (int scanPosinCG = lastScanPosinCG; scanPosinCG >= 0; scanPosinCG--)
         {
             scanPos = cgScanPos * cgSize + scanPosinCG;
-            if ((int)scanPos > lastScanPos)
-                continue;
 
             /* if the coefficient was coded, measure the RD cost of it as the last non-zero and then
              * continue as if it were uncoded. If the coefficient was already uncoded, remove the
@@ -1137,8 +1115,8 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
 
     // Average 49.62 pixels
     /* clean uncoded coefficients */
-    X265_CHECK((uint32_t)(fastMin(lastScanPos, bestLastIdx) | (SCAN_SET_SIZE - 1)) < trSize * trSize, "array beyond bound\n");
-    for (int pos = bestLastIdx; pos <= (fastMin(lastScanPos, bestLastIdx) | (SCAN_SET_SIZE - 1)); pos++)
+    X265_CHECK((uint32_t)(X265_MIN(lastScanPos, bestLastIdx) | (SCAN_SET_SIZE - 1)) < trSize * trSize, "array beyond bound\n");
+    for (int pos = bestLastIdx; pos <= (X265_MIN(lastScanPos, bestLastIdx) | (SCAN_SET_SIZE - 1)); pos++)
     {
         dstCoeff[scan[pos]] = 0;
     }

--- a/source/common/quant.cpp
+++ b/source/common/quant.cpp
@@ -426,16 +426,6 @@ uint32_t Quant::transformNxN(const CUData& cu, const pixel* fenc, uint32_t fencS
         else
             primitives.cu[sizeIdx].dct(residual, m_resiDctCoeff, resiStride);
 
-        /* NOTE: if RDOQ is disabled globally, psy-rdoq is also disabled, so
-         * there is no risk of performing this DCT unnecessarily */
-        if (usePsy)
-        {
-            int trSize = 1 << log2TrSize;
-            /* perform DCT on source pixels for psy-rdoq */
-            primitives.cu[sizeIdx].copy_ps(m_fencShortBuf, trSize, fenc, fencStride);
-            primitives.cu[sizeIdx].dct(m_fencShortBuf, m_fencDctCoeff, trSize);
-        }
-
         if (m_nr && m_nr->offset)
         {
             /* denoise is not applied to intra residual, so DST can be ignored */
@@ -447,7 +437,7 @@ uint32_t Quant::transformNxN(const CUData& cu, const pixel* fenc, uint32_t fencS
     }
 
     if (m_rdoqLevel)
-        return (this->*rdoQuant_func[log2TrSize - 2])(cu, coeff, ttype, absPartIdx, usePsy);
+        return (this->*rdoQuant_func[log2TrSize - 2])(cu, coeff, ttype, absPartIdx, usePsy, fenc, fencStride);
     else
     {
         int deltaU[32 * 32];
@@ -601,8 +591,9 @@ void Quant::invtransformNxN(const CUData& cu, int16_t* residual, uint32_t resiSt
 
 /* Rate distortion optimized quantization for entropy coding engines using
  * probability models like CABAC */
-template<uint32_t log2TrSize>
-uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, uint32_t absPartIdx, bool usePsy)
+template <uint32_t log2TrSize>
+uint32_t Quant::rdoQuant(const CUData &cu, int16_t *dstCoeff, TextType ttype, uint32_t absPartIdx, bool usePsy,
+                         const pixel *fenc, uint32_t fencStride)
 {
     const int transformShift = MAX_TR_DYNAMIC_RANGE - X265_DEPTH - log2TrSize; /* Represents scaling through forward transform */
     int scalingListType = (cu.isIntra(absPartIdx) ? 0 : 3) + ttype;
@@ -622,6 +613,29 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
     if (!numSig)
         return 0;
     const uint32_t trSize = 1 << log2TrSize;
+    if (usePsy)
+    {
+        /* Prediction candidates share the source transform for the same image block. */
+        const uint32_t sourcePartIdx = cu.m_absIdxInCTU + absPartIdx;
+        if (m_sourceDctCache.slice != cu.m_slice || m_sourceDctCache.poc != cu.m_slice->m_poc ||
+            m_sourceDctCache.log2Size != log2TrSize || m_sourceDctCache.cuAddr != cu.m_cuAddr ||
+            m_sourceDctCache.absPartIdx != sourcePartIdx)
+        {
+            primitives.cu[log2TrSize - 2].copy_ps(m_fencShortBuf, trSize, fenc, fencStride);
+            primitives.cu[log2TrSize - 2].dct(m_fencShortBuf, m_fencDctCoeff, trSize);
+            m_sourceDctCache.slice = cu.m_slice;
+            m_sourceDctCache.poc = cu.m_slice->m_poc;
+            m_sourceDctCache.log2Size = log2TrSize;
+            m_sourceDctCache.cuAddr = cu.m_cuAddr;
+            m_sourceDctCache.absPartIdx = sourcePartIdx;
+        }
+#if CHECKED_BUILD || _DEBUG
+        for (uint32_t y = 0; y < trSize; y++)
+            for (uint32_t x = 0; x < trSize; x++)
+                X265_CHECK(fenc[y * fencStride + x] == m_fencShortBuf[y * trSize + x], "source DCT cache mismatch\n");
+#endif
+    }
+
     int64_t lambda2 = m_qpParam[ttype].lambda2;
     int64_t psyScale = ((int64_t)m_psyRdoqScale * m_qpParam[ttype].lambda);
     /* unquant constants for measuring distortion. Scaling list quant coefficients have a (1 << 4)
@@ -1115,7 +1129,8 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
 
     // Average 49.62 pixels
     /* clean uncoded coefficients */
-    X265_CHECK((uint32_t)(X265_MIN(lastScanPos, bestLastIdx) | (SCAN_SET_SIZE - 1)) < trSize * trSize, "array beyond bound\n");
+    X265_CHECK((uint32_t)(X265_MIN(lastScanPos, bestLastIdx) | (SCAN_SET_SIZE - 1)) < trSize * trSize,
+               "array beyond bound\n");
     for (int pos = bestLastIdx; pos <= (X265_MIN(lastScanPos, bestLastIdx) | (SCAN_SET_SIZE - 1)); pos++)
     {
         dstCoeff[scan[pos]] = 0;

--- a/source/common/quant.cpp
+++ b/source/common/quant.cpp
@@ -1113,8 +1113,6 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
         X265_CHECK((cgScanPos << MLS_CG_SIZE) == (int)scanPos, "scanPos mistake\n");
         cgRdStats.sigCost0 = costSig[scanPos];
 
-        costCoeffGroupSig[cgScanPos] = 0;
-
         /* nothing to do at this case */
         X265_CHECK(cgLastScanPos >= 0, "cgLastScanPos check failure\n");
 

--- a/source/common/quant.cpp
+++ b/source/common/quant.cpp
@@ -739,45 +739,6 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
             primitives.cu[log2TrSize - 2].nonPsyRdoQuant(m_resiDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, blkPos);
         }
     }
-    static const uint8_t table_cnt[5][SCAN_SET_SIZE] =
-    {
-        // patternSigCtx = 0
-        {
-            2, 1, 1, 0,
-            1, 1, 0, 0,
-            1, 0, 0, 0,
-            0, 0, 0, 0,
-        },
-        // patternSigCtx = 1
-        {
-            2, 2, 2, 2,
-            1, 1, 1, 1,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-        },
-        // patternSigCtx = 2
-        {
-            2, 1, 0, 0,
-            2, 1, 0, 0,
-            2, 1, 0, 0,
-            2, 1, 0, 0,
-        },
-        // patternSigCtx = 3
-        {
-            2, 2, 2, 2,
-            2, 2, 2, 2,
-            2, 2, 2, 2,
-            2, 2, 2, 2,
-        },
-        // 4x4
-        {
-            0, 1, 4, 5,
-            2, 3, 4, 5,
-            6, 6, 8, 8,
-            7, 7, 8, 8
-        }
-    };
-
     /* iterate over coding groups in reverse scan order */
     for (int cgScanPos = cgLastScanPos; cgScanPos >= 0; cgScanPos--)
     {
@@ -813,43 +774,11 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                 primitives.cu[log2TrSize - 2].psyRdoQuant_1p(m_resiDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, blkPos);
                 primitives.cu[log2TrSize - 2].psyRdoQuant_2p(m_resiDctCoeff, m_fencDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, &psyScale, blkPos);
 #endif
-                blkPos = scan[scanPosBase];
-                for (int y = 0; y < MLS_CG_SIZE; y++)
-                {
-                    for (int x = 0; x < MLS_CG_SIZE; x++)
-                    {
-                        const uint32_t scanPosOffset =  y * MLS_CG_SIZE + x;
-                        const uint32_t ctxSig = table_cnt[patternSigCtx][scan4x4[scanPosOffset]] + ctxSigOffset;
-                        X265_CHECK(trSize > 4, "trSize check failure\n");
-                        X265_CHECK(ctxSig == getSigCtxInc(patternSigCtx, log2TrSize, trSize, scan[scanPosBase + scanPosOffset], bIsLuma, firstSignificanceMapContext), "sigCtx check failure\n");
-
-                        costSig[scanPosBase + scanPosOffset] = SIGCOST(estBitsSbac.significantBits[0][ctxSig]);
-                        costCoeff[scanPosBase + scanPosOffset] = costUncoded[blkPos + x];
-                        sigRateDelta[blkPos + x] = estBitsSbac.significantBits[1][ctxSig] - estBitsSbac.significantBits[0][ctxSig];
-                    }
-                    blkPos += trSize;
-                }
             }
             else
             {
                 // non-psy path
                 primitives.cu[log2TrSize - 2].nonPsyRdoQuant(m_resiDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, blkPos);
-                blkPos = scan[scanPosBase];
-                for (int y = 0; y < MLS_CG_SIZE; y++)
-                {
-                    for (int x = 0; x < MLS_CG_SIZE; x++)
-                    {
-                        const uint32_t scanPosOffset =  y * MLS_CG_SIZE + x;
-                        const uint32_t ctxSig = table_cnt[patternSigCtx][scan4x4[scanPosOffset]] + ctxSigOffset;
-                        X265_CHECK(trSize > 4, "trSize check failure\n");
-                        X265_CHECK(ctxSig == getSigCtxInc(patternSigCtx, log2TrSize, trSize, scan[scanPosBase + scanPosOffset], bIsLuma, firstSignificanceMapContext), "sigCtx check failure\n");
-
-                        costSig[scanPosBase + scanPosOffset] = SIGCOST(estBitsSbac.significantBits[0][ctxSig]);
-                        costCoeff[scanPosBase + scanPosOffset] = costUncoded[blkPos + x];
-                        sigRateDelta[blkPos + x] = estBitsSbac.significantBits[1][ctxSig] - estBitsSbac.significantBits[0][ctxSig];
-                    }
-                    blkPos += trSize;
-                }
             }
 
             /* there were no coded coefficients in this coefficient group */
@@ -908,11 +837,9 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
 
             // coefficient level estimation
             const int* greaterOneBits = estBitsSbac.greaterOneBits[4 * ctxSet + c1];
-            //const uint32_t ctxSig = (blkPos == 0) ? 0 : table_cnt[(trSize == 4) ? 4 : patternSigCtx][scan4x4[scanPosinCG]] + ctxSigOffset;
             static const uint64_t table_cnt64[4] = {0x0000000100110112ULL, 0x0000000011112222ULL, 0x0012001200120012ULL, 0x2222222222222222ULL};
             uint64_t ctxCnt = (trSize == 4) ? 0x8877886654325410ULL : table_cnt64[patternSigCtx];
             const uint32_t ctxSig = (blkPos == 0) ? 0 : ((ctxCnt >> (4 * scan4x4[scanPosinCG])) & 0xF) + ctxSigOffset;
-            // NOTE: above equal to 'table_cnt[(trSize == 4) ? 4 : patternSigCtx][scan4x4[scanPosinCG]] + ctxSigOffset'
             X265_CHECK(ctxSig == getSigCtxInc(patternSigCtx, log2TrSize, trSize, blkPos, bIsLuma, firstSignificanceMapContext), "sigCtx check failure\n");
 
             if (!(subFlagMask & 1))

--- a/source/common/quant.cpp
+++ b/source/common/quant.cpp
@@ -884,13 +884,14 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
              * FIX15 nature of the CABAC cost tables minus the forward transform scale */
 
             /* cost of not coding this coefficient (all distortion, no signal bits) */
-            costUncoded[blkPos] = ((int64_t)signCoef * signCoef) << scaleBits;
+            int64_t uncodedCost = ((int64_t)signCoef * signCoef) << scaleBits;
             X265_CHECK((!!scanPos ^ !!blkPos) == 0, "failed on (blkPos=0 && scanPos!=0)\n");
             if (usePsyMask & scanPos)
                 /* when no residual coefficient is coded, predicted coef == recon coef */
-                costUncoded[blkPos] -= PSYVALUE(predictedCoef);
+                uncodedCost -= PSYVALUE(predictedCoef);
 
-            totalUncodedCost += costUncoded[blkPos];
+            costUncoded[blkPos] = uncodedCost;
+            totalUncodedCost += uncodedCost;
 
             if (scanPos > (uint32_t)lastScanPos)
             {
@@ -901,7 +902,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                 /* No non-zero coefficient yet found, but this does not mean
                  * there is no uncoded-cost for this coefficient. Pre-
                  * quantization the coefficient may have been non-zero */
-                totalRdCost += costUncoded[blkPos];
+                totalRdCost += uncodedCost;
                 continue;
             }
 
@@ -919,7 +920,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                 // fast zero coeff path
                 /* set default costs to uncoded costs */
                 costSig[scanPos] = SIGCOST(estBitsSbac.significantBits[0][ctxSig]);
-                costCoeff[scanPos] = costUncoded[blkPos] + costSig[scanPos];
+                costCoeff[scanPos] = uncodedCost + costSig[scanPos];
                 sigRateDelta[blkPos] = estBitsSbac.significantBits[1][ctxSig] - estBitsSbac.significantBits[0][ctxSig];
                 totalRdCost += costCoeff[scanPos];
                 rateIncUp[blkPos] = greaterOneBits[0];
@@ -954,7 +955,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                     {
                         /* set default costs to uncoded costs */
                         costSig[scanPos] = SIGCOST(estBitsSbac.significantBits[0][ctxSig]);
-                        costCoeff[scanPos] = costUncoded[blkPos] + costSig[scanPos];
+                        costCoeff[scanPos] = uncodedCost + costSig[scanPos];
                     }
                     sigRateDelta[blkPos] = estBitsSbac.significantBits[1][ctxSig] - estBitsSbac.significantBits[0][ctxSig];
                     sigCoefBits = estBitsSbac.significantBits[1][ctxSig];
@@ -1101,7 +1102,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                 {
                     sigCoeffGroupFlag64 |= cgBlkPosMask;
                     cgRdStats.codedLevelAndDist += costCoeff[scanPos] - costSig[scanPos];
-                    cgRdStats.uncodedDist += costUncoded[blkPos];
+                    cgRdStats.uncodedDist += uncodedCost;
                     cgRdStats.nnzBeforePos0 += scanPosinCG;
                 }
             }

--- a/source/common/quant.cpp
+++ b/source/common/quant.cpp
@@ -892,16 +892,6 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
 
             totalUncodedCost += costUncoded[blkPos];
 
-            // coefficient level estimation
-            const int* greaterOneBits = estBitsSbac.greaterOneBits[4 * ctxSet + c1];
-            //const uint32_t ctxSig = (blkPos == 0) ? 0 : table_cnt[(trSize == 4) ? 4 : patternSigCtx][scan4x4[scanPosinCG]] + ctxSigOffset;
-            static const uint64_t table_cnt64[4] = {0x0000000100110112ULL, 0x0000000011112222ULL, 0x0012001200120012ULL, 0x2222222222222222ULL};
-            uint64_t ctxCnt = (trSize == 4) ? 0x8877886654325410ULL : table_cnt64[patternSigCtx];
-            const uint32_t ctxSig = (blkPos == 0) ? 0 : ((ctxCnt >> (4 * scan4x4[scanPosinCG])) & 0xF) + ctxSigOffset;
-            // NOTE: above equal to 'table_cnt[(trSize == 4) ? 4 : patternSigCtx][scan4x4[scanPosinCG]] + ctxSigOffset'
-            X265_CHECK(ctxSig == getSigCtxInc(patternSigCtx, log2TrSize, trSize, blkPos, bIsLuma, firstSignificanceMapContext), "sigCtx check failure\n");
-
-            // before find lastest non-zero coeff
             if (scanPos > (uint32_t)lastScanPos)
             {
                 /* coefficients after lastNZ have no distortion signal cost */
@@ -912,8 +902,19 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                  * there is no uncoded-cost for this coefficient. Pre-
                  * quantization the coefficient may have been non-zero */
                 totalRdCost += costUncoded[blkPos];
+                continue;
             }
-            else if (!(subFlagMask & 1))
+
+            // coefficient level estimation
+            const int* greaterOneBits = estBitsSbac.greaterOneBits[4 * ctxSet + c1];
+            //const uint32_t ctxSig = (blkPos == 0) ? 0 : table_cnt[(trSize == 4) ? 4 : patternSigCtx][scan4x4[scanPosinCG]] + ctxSigOffset;
+            static const uint64_t table_cnt64[4] = {0x0000000100110112ULL, 0x0000000011112222ULL, 0x0012001200120012ULL, 0x2222222222222222ULL};
+            uint64_t ctxCnt = (trSize == 4) ? 0x8877886654325410ULL : table_cnt64[patternSigCtx];
+            const uint32_t ctxSig = (blkPos == 0) ? 0 : ((ctxCnt >> (4 * scan4x4[scanPosinCG])) & 0xF) + ctxSigOffset;
+            // NOTE: above equal to 'table_cnt[(trSize == 4) ? 4 : patternSigCtx][scan4x4[scanPosinCG]] + ctxSigOffset'
+            X265_CHECK(ctxSig == getSigCtxInc(patternSigCtx, log2TrSize, trSize, blkPos, bIsLuma, firstSignificanceMapContext), "sigCtx check failure\n");
+
+            if (!(subFlagMask & 1))
             {
                 // fast zero coeff path
                 /* set default costs to uncoded costs */
@@ -1494,4 +1495,3 @@ uint32_t Quant::getSigCtxInc(uint32_t patternSigCtx, uint32_t log2TrSize, uint32
 
     return (bIsLuma && (posX | posY) >= 4) ? 3 + offset : offset;
 }
-

--- a/source/common/quant.cpp
+++ b/source/common/quant.cpp
@@ -655,6 +655,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
 
     const uint32_t cgSize = (1 << MLS_CG_SIZE); /* 4x4 num coef = 16 */
     bool bIsLuma = ttype == TEXT_LUMA;
+    const uint32_t signHideMask = cu.m_slice->m_pps->bSignHideEnabled ? -1 : 0;
 
     /* total rate distortion cost of transform block, as CBF=0 */
     int64_t totalUncodedCost = 0;
@@ -666,6 +667,11 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
 
     TUEntropyCodingParameters codeParams;
     cu.getTUEntropyCodingParameters(codeParams, absPartIdx, log2TrSize, bIsLuma);
+    const uint16_t* const scan = codeParams.scan;
+    const uint16_t* const scanCG = codeParams.scanCG;
+    const uint16_t* const scan4x4 = g_scan4x4[codeParams.scanType];
+    const ScanType scanType = codeParams.scanType;
+    const uint32_t firstSignificanceMapContext = codeParams.firstSignificanceMapContext;
     const uint32_t log2TrSizeCG = log2TrSize - 2;
     const uint32_t cgNum = 1 << (log2TrSizeCG * 2);
     const uint32_t cgStride = (trSize >> MLS_CG_LOG2_SIZE);
@@ -680,7 +686,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
     memset(coeffSign, 0, sizeof(coeffNum) * sizeof(uint16_t));
     memset(coeffFlag, 0, sizeof(coeffNum) * sizeof(uint16_t));
 #endif
-    const int lastScanPos = primitives.scanPosLast(codeParams.scan, dstCoeff, coeffSign, coeffFlag, coeffNum, numSig, g_scan4x4[codeParams.scanType], trSize);
+    const int lastScanPos = primitives.scanPosLast(scan, dstCoeff, coeffSign, coeffFlag, coeffNum, numSig, scan4x4, trSize);
     const int cgLastScanPos = (lastScanPos >> LOG2_SCAN_SET_SIZE);
 
 
@@ -706,7 +712,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
         {
             X265_CHECK(coeffNum[cgScanPos] == 0, "count of coeff failure\n");
             uint32_t scanPosBase = (cgScanPos << MLS_CG_SIZE);
-            uint32_t blkPos      = codeParams.scan[scanPosBase];
+            uint32_t blkPos      = scan[scanPosBase];
 #if X265_ARCH_X86
             bool enable512 = detect512();
             if (enable512)
@@ -729,7 +735,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
         {
             X265_CHECK(coeffNum[cgScanPos] == 0, "count of coeff failure\n");
             uint32_t scanPosBase = (cgScanPos << MLS_CG_SIZE);
-            uint32_t blkPos      = codeParams.scan[scanPosBase];
+            uint32_t blkPos      = scan[scanPosBase];
             primitives.cu[log2TrSize - 2].nonPsyRdoQuant(m_resiDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, blkPos);
         }
     }
@@ -776,12 +782,12 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
     for (int cgScanPos = cgLastScanPos; cgScanPos >= 0; cgScanPos--)
     {
         uint32_t ctxSet = (cgScanPos && bIsLuma) ? 2 : 0;
-        const uint32_t cgBlkPos = codeParams.scanCG[cgScanPos];
+        const uint32_t cgBlkPos = scanCG[cgScanPos];
         const uint32_t cgPosY   = cgBlkPos >> log2TrSizeCG;
         const uint32_t cgPosX   = cgBlkPos & ((1 << log2TrSizeCG) - 1);
         const uint64_t cgBlkPosMask = ((uint64_t)1 << cgBlkPos);
         const int patternSigCtx = calcPatternSigCtx(sigCoeffGroupFlag64, cgPosX, cgPosY, cgBlkPos, cgStride);
-        const int ctxSigOffset = codeParams.firstSignificanceMapContext + (cgScanPos && bIsLuma ? 3 : 0);
+        const int ctxSigOffset = firstSignificanceMapContext + (cgScanPos && bIsLuma ? 3 : 0);
 
         if (c1 == 0)
             ctxSet++;
@@ -791,7 +797,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
         {
             // TODO: does we need zero-coeff cost?
             const uint32_t scanPosBase = (cgScanPos << MLS_CG_SIZE);
-            uint32_t blkPos = codeParams.scan[scanPosBase];
+            uint32_t blkPos = scan[scanPosBase];
             if (usePsyMask)
             {
 #if X265_ARCH_X86
@@ -807,15 +813,15 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                 primitives.cu[log2TrSize - 2].psyRdoQuant_1p(m_resiDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, blkPos);
                 primitives.cu[log2TrSize - 2].psyRdoQuant_2p(m_resiDctCoeff, m_fencDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, &psyScale, blkPos);
 #endif
-                blkPos = codeParams.scan[scanPosBase];
+                blkPos = scan[scanPosBase];
                 for (int y = 0; y < MLS_CG_SIZE; y++)
                 {
                     for (int x = 0; x < MLS_CG_SIZE; x++)
                     {
                         const uint32_t scanPosOffset =  y * MLS_CG_SIZE + x;
-                        const uint32_t ctxSig = table_cnt[patternSigCtx][g_scan4x4[codeParams.scanType][scanPosOffset]] + ctxSigOffset;
+                        const uint32_t ctxSig = table_cnt[patternSigCtx][scan4x4[scanPosOffset]] + ctxSigOffset;
                         X265_CHECK(trSize > 4, "trSize check failure\n");
-                        X265_CHECK(ctxSig == getSigCtxInc(patternSigCtx, log2TrSize, trSize, codeParams.scan[scanPosBase + scanPosOffset], bIsLuma, codeParams.firstSignificanceMapContext), "sigCtx check failure\n");
+                        X265_CHECK(ctxSig == getSigCtxInc(patternSigCtx, log2TrSize, trSize, scan[scanPosBase + scanPosOffset], bIsLuma, firstSignificanceMapContext), "sigCtx check failure\n");
 
                         costSig[scanPosBase + scanPosOffset] = SIGCOST(estBitsSbac.significantBits[0][ctxSig]);
                         costCoeff[scanPosBase + scanPosOffset] = costUncoded[blkPos + x];
@@ -828,15 +834,15 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
             {
                 // non-psy path
                 primitives.cu[log2TrSize - 2].nonPsyRdoQuant(m_resiDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, blkPos);
-                blkPos = codeParams.scan[scanPosBase];
+                blkPos = scan[scanPosBase];
                 for (int y = 0; y < MLS_CG_SIZE; y++)
                 {
                     for (int x = 0; x < MLS_CG_SIZE; x++)
                     {
                         const uint32_t scanPosOffset =  y * MLS_CG_SIZE + x;
-                        const uint32_t ctxSig = table_cnt[patternSigCtx][g_scan4x4[codeParams.scanType][scanPosOffset]] + ctxSigOffset;
+                        const uint32_t ctxSig = table_cnt[patternSigCtx][scan4x4[scanPosOffset]] + ctxSigOffset;
                         X265_CHECK(trSize > 4, "trSize check failure\n");
-                        X265_CHECK(ctxSig == getSigCtxInc(patternSigCtx, log2TrSize, trSize, codeParams.scan[scanPosBase + scanPosOffset], bIsLuma, codeParams.firstSignificanceMapContext), "sigCtx check failure\n");
+                        X265_CHECK(ctxSig == getSigCtxInc(patternSigCtx, log2TrSize, trSize, scan[scanPosBase + scanPosOffset], bIsLuma, firstSignificanceMapContext), "sigCtx check failure\n");
 
                         costSig[scanPosBase + scanPosOffset] = SIGCOST(estBitsSbac.significantBits[0][ctxSig]);
                         costCoeff[scanPosBase + scanPosOffset] = costUncoded[blkPos + x];
@@ -868,7 +874,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
         for (int scanPosinCG = cgSize - 1; scanPosinCG >= 0; scanPosinCG--)
         {
             scanPos              = (cgScanPos << MLS_CG_SIZE) + scanPosinCG;
-            uint32_t blkPos      = codeParams.scan[scanPos];
+            uint32_t blkPos      = scan[scanPos];
             uint32_t maxAbsLevel = dstCoeff[blkPos];                  /* abs(quantized coeff) */
             int signCoef         = m_resiDctCoeff[blkPos];            /* pre-quantization DCT coeff */
             int predictedCoef    = m_fencDctCoeff[blkPos] - signCoef; /* predicted DCT = source DCT - residual DCT*/
@@ -888,12 +894,12 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
 
             // coefficient level estimation
             const int* greaterOneBits = estBitsSbac.greaterOneBits[4 * ctxSet + c1];
-            //const uint32_t ctxSig = (blkPos == 0) ? 0 : table_cnt[(trSize == 4) ? 4 : patternSigCtx][g_scan4x4[codeParams.scanType][scanPosinCG]] + ctxSigOffset;
+            //const uint32_t ctxSig = (blkPos == 0) ? 0 : table_cnt[(trSize == 4) ? 4 : patternSigCtx][scan4x4[scanPosinCG]] + ctxSigOffset;
             static const uint64_t table_cnt64[4] = {0x0000000100110112ULL, 0x0000000011112222ULL, 0x0012001200120012ULL, 0x2222222222222222ULL};
             uint64_t ctxCnt = (trSize == 4) ? 0x8877886654325410ULL : table_cnt64[patternSigCtx];
-            const uint32_t ctxSig = (blkPos == 0) ? 0 : ((ctxCnt >> (4 * g_scan4x4[codeParams.scanType][scanPosinCG])) & 0xF) + ctxSigOffset;
-            // NOTE: above equal to 'table_cnt[(trSize == 4) ? 4 : patternSigCtx][g_scan4x4[codeParams.scanType][scanPosinCG]] + ctxSigOffset'
-            X265_CHECK(ctxSig == getSigCtxInc(patternSigCtx, log2TrSize, trSize, blkPos, bIsLuma, codeParams.firstSignificanceMapContext), "sigCtx check failure\n");
+            const uint32_t ctxSig = (blkPos == 0) ? 0 : ((ctxCnt >> (4 * scan4x4[scanPosinCG])) & 0xF) + ctxSigOffset;
+            // NOTE: above equal to 'table_cnt[(trSize == 4) ? 4 : patternSigCtx][scan4x4[scanPosinCG]] + ctxSigOffset'
+            X265_CHECK(ctxSig == getSigCtxInc(patternSigCtx, log2TrSize, trSize, blkPos, bIsLuma, firstSignificanceMapContext), "sigCtx check failure\n");
 
             // before find lastest non-zero coeff
             if (scanPos > (uint32_t)lastScanPos)
@@ -1024,7 +1030,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                 totalRdCost += costCoeff[scanPos];
 
                 /* record costs for sign-hiding performed at the end */
-                if ((cu.m_slice->m_pps->bSignHideEnabled ? ~0 : 0) & level)
+                if (signHideMask & level)
                 {
                     const int32_t diff0 = level - 1 - baseLevel;
                     const int32_t diff2 = level + 1 - baseLevel;
@@ -1145,7 +1151,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                 costCoeffGroupSig[cgScanPos] = SIGCOST(estBitsSbac.significantCoeffGroupBits[sigCtx][0]);
 
                 /* reset all coeffs to 0. UNCODE THIS COEFF GROUP! */
-                const uint32_t blkPos = codeParams.scan[cgScanPos * cgSize];
+                const uint32_t blkPos = scan[cgScanPos * cgSize];
                 memset(&dstCoeff[blkPos + 0 * trSize], 0, 4 * sizeof(*dstCoeff));
                 memset(&dstCoeff[blkPos + 1 * trSize], 0, 4 * sizeof(*dstCoeff));
                 memset(&dstCoeff[blkPos + 2 * trSize], 0, 4 * sizeof(*dstCoeff));
@@ -1192,7 +1198,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
             /* the presence of these coefficient groups are inferred, they have no bit in
              * sigCoeffGroupFlag64 and no saved costCoeffGroupSig[] cost */
         }
-        else if (sigCoeffGroupFlag64 & (1ULL << codeParams.scanCG[cgScanPos]))
+        else if (sigCoeffGroupFlag64 & (1ULL << scanCG[cgScanPos]))
         {
             /* remove cost of significant coeff group flag, the group's presence would be inferred
              * from lastNZ if it were present in this group */
@@ -1214,12 +1220,12 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
             /* if the coefficient was coded, measure the RD cost of it as the last non-zero and then
              * continue as if it were uncoded. If the coefficient was already uncoded, remove the
              * cost of signaling it as not-significant */
-            uint32_t blkPos = codeParams.scan[scanPos];
+            uint32_t blkPos = scan[scanPos];
             if (dstCoeff[blkPos])
             {
                 // Calculates the cost of signaling the last significant coefficient in the block 
                 uint32_t pos[2] = { (blkPos & (trSize - 1)), (blkPos >> log2TrSize) };
-                if (codeParams.scanType == SCAN_VER)
+                if (scanType == SCAN_VER)
                     std::swap(pos[0], pos[1]);
                 uint32_t bitsLastNZ = 0;
 
@@ -1258,7 +1264,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
     numSig = 0;
     for (int pos = 0; pos < bestLastIdx; pos++)
     {
-        int blkPos = codeParams.scan[pos];
+        int blkPos = scan[pos];
         int level  = dstCoeff[blkPos];
         numSig += (level != 0);
 
@@ -1271,11 +1277,11 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
     X265_CHECK((uint32_t)(fastMin(lastScanPos, bestLastIdx) | (SCAN_SET_SIZE - 1)) < trSize * trSize, "array beyond bound\n");
     for (int pos = bestLastIdx; pos <= (fastMin(lastScanPos, bestLastIdx) | (SCAN_SET_SIZE - 1)); pos++)
     {
-        dstCoeff[codeParams.scan[pos]] = 0;
+        dstCoeff[scan[pos]] = 0;
     }
     for (int pos = (bestLastIdx & ~(SCAN_SET_SIZE - 1)) + SCAN_SET_SIZE; pos <= lastScanPos; pos += SCAN_SET_SIZE)
     {
-        const uint32_t blkPos = codeParams.scan[pos];
+        const uint32_t blkPos = scan[pos];
         memset(&dstCoeff[blkPos + 0 * trSize], 0, 4 * sizeof(*dstCoeff));
         memset(&dstCoeff[blkPos + 1 * trSize], 0, 4 * sizeof(*dstCoeff));
         memset(&dstCoeff[blkPos + 2 * trSize], 0, 4 * sizeof(*dstCoeff));
@@ -1283,7 +1289,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
     }
 
     /* rate-distortion based sign-hiding */
-    if (cu.m_slice->m_pps->bSignHideEnabled && numSig >= 2)
+    if (signHideMask && numSig >= 2)
     {
         const int realLastScanPos = (bestLastIdx - 1) >> LOG2_SCAN_SET_SIZE;
         int lastCG = 1;
@@ -1293,24 +1299,24 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
             int subPos = subSet << LOG2_SCAN_SET_SIZE;
             int n;
 
-            if (!(sigCoeffGroupFlag64 & (1ULL << codeParams.scanCG[subSet])))
+            if (!(sigCoeffGroupFlag64 & (1ULL << scanCG[subSet])))
                 continue;
 
             /* measure distance between first and last non-zero coef in this
              * coding group */
-            const uint32_t posFirstLast = primitives.findPosFirstLast(&dstCoeff[codeParams.scan[subPos]], trSize, g_scan4x4[codeParams.scanType]);
+            const uint32_t posFirstLast = primitives.findPosFirstLast(&dstCoeff[scan[subPos]], trSize, scan4x4);
             const int firstNZPosInCG = (uint8_t)posFirstLast;
             const int lastNZPosInCG = (int8_t)(posFirstLast >> 8);
             const uint32_t absSumSign = posFirstLast;
 
             if (lastNZPosInCG - firstNZPosInCG >= SBH_THRESHOLD)
             {
-                const int32_t signbit = ((int32_t)dstCoeff[codeParams.scan[subPos + firstNZPosInCG]]);
+                const int32_t signbit = ((int32_t)dstCoeff[scan[subPos + firstNZPosInCG]]);
 
 #if CHECKED_BUILD || _DEBUG
                 int32_t absSum_dummy = 0;
                 for (n = firstNZPosInCG; n <= lastNZPosInCG; n++)
-                    absSum_dummy += dstCoeff[codeParams.scan[n + subPos]];
+                    absSum_dummy += dstCoeff[scan[n + subPos]];
                 X265_CHECK(((uint32_t)absSum_dummy & 1) == (absSumSign >> 31), "absSumSign check failure\n");
 #endif
 
@@ -1325,11 +1331,11 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                     uint32_t minPos = 0;
                     int8_t finalChange = 0;
                     int curChange = 0;
-                    uint32_t lastCoeffAdjust = (lastCG & (abs(dstCoeff[codeParams.scan[lastNZPosInCG + subPos]]) == 1)) * 4 * IEP_RATE;
+                    uint32_t lastCoeffAdjust = (lastCG & (abs(dstCoeff[scan[lastNZPosInCG + subPos]]) == 1)) * 4 * IEP_RATE;
 
                     for (n = (lastCG ? lastNZPosInCG : SCAN_SET_SIZE - 1); n >= 0; --n)
                     {
-                        const uint32_t blkPos = codeParams.scan[n + subPos];
+                        const uint32_t blkPos = scan[n + subPos];
                         const int32_t signCoef = m_resiDctCoeff[blkPos]; /* pre-quantization DCT coeff */
                         const int absLevel = abs(dstCoeff[blkPos]);
                         // TODO: this is constant in non-scaling mode

--- a/source/common/quant.cpp
+++ b/source/common/quant.cpp
@@ -703,42 +703,20 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
     memset(&costCoeff[(cgLastScanPos + 1) << MLS_CG_SIZE], 0, zeroCG * MLS_CG_BLK_SIZE * sizeof(int64_t));
     memset(&costSig[(cgLastScanPos + 1) << MLS_CG_SIZE], 0, zeroCG * MLS_CG_BLK_SIZE * sizeof(int64_t));
 
-    /* sum zero coeff (uncodec) cost */
-
-    // TODO: does we need these cost?
+    /* Initialize the uncoded distortion for every coefficient. This lets the
+     * coefficient loop replace uncoded costs with coded costs as needed. */
     if (usePsyMask)
     {
-        for (int cgScanPos = cgLastScanPos + 1; cgScanPos < (int)cgNum ; cgScanPos++)
-        {
-            X265_CHECK(coeffNum[cgScanPos] == 0, "count of coeff failure\n");
-            uint32_t scanPosBase = (cgScanPos << MLS_CG_SIZE);
-            uint32_t blkPos      = scan[scanPosBase];
-#if X265_ARCH_X86
-            bool enable512 = detect512();
-            if (enable512)
-                primitives.cu[log2TrSize - 2].psyRdoQuant(m_resiDctCoeff, m_fencDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, &psyScale, blkPos);
-            else
-            {
-                primitives.cu[log2TrSize - 2].psyRdoQuant_1p(m_resiDctCoeff,  costUncoded, &totalUncodedCost, &totalRdCost,blkPos);
-                primitives.cu[log2TrSize - 2].psyRdoQuant_2p(m_resiDctCoeff, m_fencDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, &psyScale, blkPos);
-            }
-#else
-            primitives.cu[log2TrSize - 2].psyRdoQuant_1p(m_resiDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, blkPos);
-            primitives.cu[log2TrSize - 2].psyRdoQuant_2p(m_resiDctCoeff, m_fencDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, &psyScale, blkPos);
-#endif
-        }
+        primitives.cu[log2TrSize - 2].psyRdoQuantAll(m_resiDctCoeff, m_fencDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, &psyScale);
+
+        /* DC distortion does not include the psy-RDOQ reconstruction bias. */
+        int64_t dcPsyCost = PSYVALUE(m_fencDctCoeff[0] - m_resiDctCoeff[0]);
+        costUncoded[0] += dcPsyCost;
+        totalUncodedCost += dcPsyCost;
+        totalRdCost += dcPsyCost;
     }
     else
-    {
-        // non-psy path
-        for (int cgScanPos = cgLastScanPos + 1; cgScanPos < (int)cgNum ; cgScanPos++)
-        {
-            X265_CHECK(coeffNum[cgScanPos] == 0, "count of coeff failure\n");
-            uint32_t scanPosBase = (cgScanPos << MLS_CG_SIZE);
-            uint32_t blkPos      = scan[scanPosBase];
-            primitives.cu[log2TrSize - 2].nonPsyRdoQuant(m_resiDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, blkPos);
-        }
-    }
+        primitives.cu[log2TrSize - 2].nonPsyRdoQuantAll(m_resiDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost);
     /* iterate over coding groups in reverse scan order */
     for (int cgScanPos = cgLastScanPos; cgScanPos >= 0; cgScanPos--)
     {
@@ -756,31 +734,6 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
 
         if (cgScanPos && (coeffNum[cgScanPos] == 0))
         {
-            // TODO: does we need zero-coeff cost?
-            const uint32_t scanPosBase = (cgScanPos << MLS_CG_SIZE);
-            uint32_t blkPos = scan[scanPosBase];
-            if (usePsyMask)
-            {
-#if X265_ARCH_X86
-                bool enable512 = detect512();
-                if (enable512)
-                    primitives.cu[log2TrSize - 2].psyRdoQuant(m_resiDctCoeff, m_fencDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, &psyScale, blkPos);
-                else
-                {
-                    primitives.cu[log2TrSize - 2].psyRdoQuant_1p(m_resiDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, blkPos);
-                    primitives.cu[log2TrSize - 2].psyRdoQuant_2p(m_resiDctCoeff, m_fencDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, &psyScale, blkPos);
-                }
-#else
-                primitives.cu[log2TrSize - 2].psyRdoQuant_1p(m_resiDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, blkPos);
-                primitives.cu[log2TrSize - 2].psyRdoQuant_2p(m_resiDctCoeff, m_fencDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, &psyScale, blkPos);
-#endif
-            }
-            else
-            {
-                // non-psy path
-                primitives.cu[log2TrSize - 2].nonPsyRdoQuant(m_resiDctCoeff, costUncoded, &totalUncodedCost, &totalRdCost, blkPos);
-            }
-
             /* there were no coded coefficients in this coefficient group */
             {
                 uint32_t ctxSig = getSigCoeffGroupCtxInc(sigCoeffGroupFlag64, cgPosX, cgPosY, cgBlkPos, cgStride);
@@ -807,20 +760,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
             uint32_t maxAbsLevel = dstCoeff[blkPos];                  /* abs(quantized coeff) */
             int signCoef         = m_resiDctCoeff[blkPos];            /* pre-quantization DCT coeff */
             int predictedCoef    = m_fencDctCoeff[blkPos] - signCoef; /* predicted DCT = source DCT - residual DCT*/
-
-            /* RDOQ measures distortion as the squared difference between the unquantized coded level
-             * and the original DCT coefficient. The result is shifted scaleBits to account for the
-             * FIX15 nature of the CABAC cost tables minus the forward transform scale */
-
-            /* cost of not coding this coefficient (all distortion, no signal bits) */
-            int64_t uncodedCost = ((int64_t)signCoef * signCoef) << scaleBits;
-            X265_CHECK((!!scanPos ^ !!blkPos) == 0, "failed on (blkPos=0 && scanPos!=0)\n");
-            if (usePsyMask & scanPos)
-                /* when no residual coefficient is coded, predicted coef == recon coef */
-                uncodedCost -= PSYVALUE(predictedCoef);
-
-            costUncoded[blkPos] = uncodedCost;
-            totalUncodedCost += uncodedCost;
+            int64_t uncodedCost = costUncoded[blkPos];
 
             if (scanPos > (uint32_t)lastScanPos)
             {
@@ -828,10 +768,6 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                 costCoeff[scanPos] = 0;
                 costSig[scanPos] = 0;
 
-                /* No non-zero coefficient yet found, but this does not mean
-                 * there is no uncoded-cost for this coefficient. Pre-
-                 * quantization the coefficient may have been non-zero */
-                totalRdCost += uncodedCost;
                 continue;
             }
 
@@ -849,7 +785,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                 costSig[scanPos] = SIGCOST(estBitsSbac.significantBits[0][ctxSig]);
                 costCoeff[scanPos] = uncodedCost + costSig[scanPos];
                 sigRateDelta[blkPos] = estBitsSbac.significantBits[1][ctxSig] - estBitsSbac.significantBits[0][ctxSig];
-                totalRdCost += costCoeff[scanPos];
+                totalRdCost += costCoeff[scanPos] - uncodedCost;
                 rateIncUp[blkPos] = greaterOneBits[0];
 
                 subFlagMask >>= 1;
@@ -956,7 +892,7 @@ uint32_t Quant::rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, ui
                 }
 
                 dstCoeff[blkPos] = (int16_t)level;
-                totalRdCost += costCoeff[scanPos];
+                totalRdCost += costCoeff[scanPos] - uncodedCost;
 
                 /* record costs for sign-hiding performed at the end */
                 if (signHideMask & level)

--- a/source/common/quant.h
+++ b/source/common/quant.h
@@ -88,20 +88,22 @@ protected:
     int                m_rdoqLevel;
     int32_t            m_psyRdoqScale;  // dynamic range [0,50] * 256 = 14-bits
     int16_t*           m_resiDctCoeff;
-    int16_t*           m_fencDctCoeff;
     int16_t*           m_fencShortBuf;
+
+    enum { SOURCE_DCT_COEFFS = 16 + 64 + 256 + 1024 };
 
     struct SourceDctCache
     {
         /* Slice objects can be recycled, so the picture order count is part of the key. */
         const Slice *slice;
-        uint32_t log2Size;
         int poc;
         uint32_t cuAddr;
         uint32_t absPartIdx;
+        int16_t* coeff;
+        int16_t* pixels;
 
-        SourceDctCache() : slice(NULL), log2Size(0), poc(0), cuAddr(0), absPartIdx(0) {}
-    } m_sourceDctCache;
+        SourceDctCache() : slice(NULL), poc(0), cuAddr(0), absPartIdx(0), coeff(NULL), pixels(NULL) {}
+    } m_sourceDctCache[NUM_TR_SIZE];
 
     enum { IEP_RATE = 32768 }; /* FIX15 cost of an equal probable bit */
 

--- a/source/common/quant.h
+++ b/source/common/quant.h
@@ -34,6 +34,7 @@ namespace X265_NS {
 
 class CUData;
 class Entropy;
+class Slice;
 struct TUEntropyCodingParameters;
 
 struct QpParam
@@ -89,6 +90,18 @@ protected:
     int16_t*           m_resiDctCoeff;
     int16_t*           m_fencDctCoeff;
     int16_t*           m_fencShortBuf;
+
+    struct SourceDctCache
+    {
+        /* Slice objects can be recycled, so the picture order count is part of the key. */
+        const Slice *slice;
+        uint32_t log2Size;
+        int poc;
+        uint32_t cuAddr;
+        uint32_t absPartIdx;
+
+        SourceDctCache() : slice(NULL), log2Size(0), poc(0), cuAddr(0), absPartIdx(0) {}
+    } m_sourceDctCache;
 
     enum { IEP_RATE = 32768 }; /* FIX15 cost of an equal probable bit */
 
@@ -155,13 +168,15 @@ protected:
 
     uint32_t signBitHidingHDQ(int16_t* qcoeff, int32_t* deltaU, uint32_t numSig, const TUEntropyCodingParameters &codingParameters, uint32_t log2TrSize);
 
-    template<uint32_t log2TrSize>
-    uint32_t rdoQuant(const CUData& cu, int16_t* dstCoeff, TextType ttype, uint32_t absPartIdx, bool usePsy);
+    template <uint32_t log2TrSize>
+    uint32_t rdoQuant(const CUData &cu, int16_t *dstCoeff, TextType ttype, uint32_t absPartIdx, bool usePsy,
+                      const pixel *fenc, uint32_t fencStride);
 
-public:
-    typedef uint32_t (Quant::*rdoQuant_t)(const CUData& cu, int16_t* dstCoeff, TextType ttype, uint32_t absPartIdx, bool usePsy);
+  public:
+    typedef uint32_t (Quant::*rdoQuant_t)(const CUData &cu, int16_t *dstCoeff, TextType ttype, uint32_t absPartIdx,
+                                          bool usePsy, const pixel *fenc, uint32_t fencStride);
 
-private:
+  private:
     static rdoQuant_t rdoQuant_func[NUM_CU_DEPTH];
 };
 }

--- a/source/common/x86/asm-primitives.cpp
+++ b/source/common/x86/asm-primitives.cpp
@@ -1477,6 +1477,12 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask) // Main10
     }
     if (cpuMask & X265_CPU_AVX2)
     {
+#if X86_64
+        p.cu[BLOCK_4x4].psyRdoQuantAll = PFX(psyRdoQuantAll4_avx2);
+        p.cu[BLOCK_8x8].psyRdoQuantAll = PFX(psyRdoQuantAll8_avx2);
+        p.cu[BLOCK_16x16].psyRdoQuantAll = PFX(psyRdoQuantAll16_avx2);
+        p.cu[BLOCK_32x32].psyRdoQuantAll = PFX(psyRdoQuantAll32_avx2);
+#endif
 #if X265_DEPTH == 12
         ASSIGN_SA8D(avx2);
 #endif
@@ -3717,6 +3723,12 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask) // Main
 #if X86_64
     if (cpuMask & X265_CPU_AVX2)
     {
+#if X86_64
+        p.cu[BLOCK_4x4].psyRdoQuantAll = PFX(psyRdoQuantAll4_avx2);
+        p.cu[BLOCK_8x8].psyRdoQuantAll = PFX(psyRdoQuantAll8_avx2);
+        p.cu[BLOCK_16x16].psyRdoQuantAll = PFX(psyRdoQuantAll16_avx2);
+        p.cu[BLOCK_32x32].psyRdoQuantAll = PFX(psyRdoQuantAll32_avx2);
+#endif
         p.cu[BLOCK_16x16].sse_ss = (pixel_sse_ss_t)PFX(pixel_ssd_ss_16x16_avx2);
         p.cu[BLOCK_32x32].sse_ss = (pixel_sse_ss_t)PFX(pixel_ssd_ss_32x32_avx2);
         p.cu[BLOCK_64x64].sse_ss = (pixel_sse_ss_t)PFX(pixel_ssd_ss_64x64_avx2);

--- a/source/common/x86/asm-primitives.cpp
+++ b/source/common/x86/asm-primitives.cpp
@@ -3184,6 +3184,14 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask) // Main10
         p.cu[BLOCK_8x8].psyRdoQuant = PFX(psyRdoQuant8_avx512);
         p.cu[BLOCK_16x16].psyRdoQuant = PFX(psyRdoQuant16_avx512);
         p.cu[BLOCK_32x32].psyRdoQuant = PFX(psyRdoQuant32_avx512);
+        p.cu[BLOCK_4x4].nonPsyRdoQuantAll = PFX(nonPsyRdoQuantAll4_avx512);
+        p.cu[BLOCK_8x8].nonPsyRdoQuantAll = PFX(nonPsyRdoQuantAll8_avx512);
+        p.cu[BLOCK_16x16].nonPsyRdoQuantAll = PFX(nonPsyRdoQuantAll16_avx512);
+        p.cu[BLOCK_32x32].nonPsyRdoQuantAll = PFX(nonPsyRdoQuantAll32_avx512);
+        p.cu[BLOCK_4x4].psyRdoQuantAll = PFX(psyRdoQuantAll4_avx512);
+        p.cu[BLOCK_8x8].psyRdoQuantAll = PFX(psyRdoQuantAll8_avx512);
+        p.cu[BLOCK_16x16].psyRdoQuantAll = PFX(psyRdoQuantAll16_avx512);
+        p.cu[BLOCK_32x32].psyRdoQuantAll = PFX(psyRdoQuantAll32_avx512);
 
         p.cu[BLOCK_32x32].sse_ss = (pixel_sse_ss_t)PFX(pixel_ssd_32x32_avx512);
         p.cu[BLOCK_64x64].sse_ss = (pixel_sse_ss_t)PFX(pixel_ssd_64x64_avx512);
@@ -5413,6 +5421,14 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask) // Main
         p.cu[BLOCK_8x8].psyRdoQuant = PFX(psyRdoQuant8_avx512);
         p.cu[BLOCK_16x16].psyRdoQuant = PFX(psyRdoQuant16_avx512);
         p.cu[BLOCK_32x32].psyRdoQuant = PFX(psyRdoQuant32_avx512);
+        p.cu[BLOCK_4x4].nonPsyRdoQuantAll = PFX(nonPsyRdoQuantAll4_avx512);
+        p.cu[BLOCK_8x8].nonPsyRdoQuantAll = PFX(nonPsyRdoQuantAll8_avx512);
+        p.cu[BLOCK_16x16].nonPsyRdoQuantAll = PFX(nonPsyRdoQuantAll16_avx512);
+        p.cu[BLOCK_32x32].nonPsyRdoQuantAll = PFX(nonPsyRdoQuantAll32_avx512);
+        p.cu[BLOCK_4x4].psyRdoQuantAll = PFX(psyRdoQuantAll4_avx512);
+        p.cu[BLOCK_8x8].psyRdoQuantAll = PFX(psyRdoQuantAll8_avx512);
+        p.cu[BLOCK_16x16].psyRdoQuantAll = PFX(psyRdoQuantAll16_avx512);
+        p.cu[BLOCK_32x32].psyRdoQuantAll = PFX(psyRdoQuantAll32_avx512);
         p.pu[LUMA_32x8].satd = PFX(pixel_satd_32x8_avx512);
         p.pu[LUMA_32x16].satd = PFX(pixel_satd_32x16_avx512);
         p.pu[LUMA_32x24].satd = PFX(pixel_satd_32x24_avx512);

--- a/source/common/x86/dct8.asm
+++ b/source/common/x86/dct8.asm
@@ -6428,6 +6428,80 @@ cglobal idct4, 3, 4, 6
     movhps          [r1 + r3], xm1
     RET
 
+%if ARCH_X86_64
+%macro PSY_RDO_QUANT_ALL_AVX2 3
+%if WIN64
+    mov             r5,         r5m
+%endif
+    ; Split the scale into a signed 32-bit low part and its high correction.
+    mov             r6,         [r5]
+    movsxd          r5,         r6d
+    sub             r6,         r5
+    sar             r6,         32
+    movd            xm6,        r5d
+    movd            xm7,        r6d
+    vpbroadcastd    m6,         xm6
+    vpbroadcastd    m7,         xm7
+    mov             r6d,        %1
+    pxor            m4,         m4
+    pxor            m8,         m8
+.loop:
+    pmovsxwq        m0,         [r0]
+    pmovsxwq        m1,         [r1]
+    psubq           m1,         m0
+    pmuldq          m2,         m0, m0
+    psllq           m2,         %2
+
+    ; Multiply four signed prediction coefficients by the full 64-bit scale.
+    pmuldq          m3,         m1, m6
+    pmuldq          m5,         m1, m7
+    psllq           m5,         32
+    paddq           m3,         m5
+%if %3 > 0
+    pcmpgtq         m5,         m8, m3
+    psrlq           m3,         %3
+    psllq           m5,         64 - %3
+    por             m3,         m5
+%endif
+    psubq           m2,         m3
+    paddq           m4,         m2
+    movu            [r2],       m2
+    add             r0,         8
+    add             r1,         8
+    add             r2,         32
+    dec             r6d
+    jnz             .loop
+
+    vextracti128    xm2,        m4, 1
+    paddq           xm4,        xm2
+    punpckhqdq      xm2,        xm4, xm4
+    paddq           xm4,        xm2
+    movq            xm0,        [r3]
+    movq            xm1,        [r4]
+    paddq           xm0,        xm4
+    paddq           xm1,        xm4
+    movq            [r3],       xm0
+    movq            [r4],       xm1
+    RET
+%endmacro
+
+INIT_YMM avx2
+cglobal psyRdoQuantAll4, 6, 7, 9
+    PSY_RDO_QUANT_ALL_AVX2 4, RDO_SCALE_4, RDO_MAX_4
+
+INIT_YMM avx2
+cglobal psyRdoQuantAll8, 6, 7, 9
+    PSY_RDO_QUANT_ALL_AVX2 16, RDO_SCALE_8, RDO_MAX_8
+
+INIT_YMM avx2
+cglobal psyRdoQuantAll16, 6, 7, 9
+    PSY_RDO_QUANT_ALL_AVX2 64, RDO_SCALE_16, RDO_MAX_16
+
+INIT_YMM avx2
+cglobal psyRdoQuantAll32, 6, 7, 9
+    PSY_RDO_QUANT_ALL_AVX2 256, RDO_SCALE_32, RDO_MAX_32
+%endif
+
 %macro NONPSY_RDO_QUANT_ALL 2
     mov             r4d,        %1
     vpxor           m3,         m3

--- a/source/common/x86/dct8.asm
+++ b/source/common/x86/dct8.asm
@@ -547,6 +547,10 @@ cextern trans8_shuf
     %define     RDO_MAX_8           1
     %define     RDO_MAX_16          0
     %define     RDO_MAX_32          0
+    %define     RDO_SCALE_4         13
+    %define     RDO_SCALE_8         15
+    %define     RDO_SCALE_16        17
+    %define     RDO_SCALE_32        19
 %elif BIT_DEPTH == 10
     %define     DCT4_SHIFT          3
     %define     DCT4_ROUND          4
@@ -560,6 +564,10 @@ cextern trans8_shuf
     %define     RDO_MAX_8           5
     %define     RDO_MAX_16          3
     %define     RDO_MAX_32          1
+    %define     RDO_SCALE_4         9
+    %define     RDO_SCALE_8         11
+    %define     RDO_SCALE_16        13
+    %define     RDO_SCALE_32        15
 %elif BIT_DEPTH == 8
     %define     DCT4_SHIFT          1
     %define     DCT4_ROUND          1
@@ -573,6 +581,10 @@ cextern trans8_shuf
     %define     RDO_MAX_8           9
     %define     RDO_MAX_16          7
     %define     RDO_MAX_32          5
+    %define     RDO_SCALE_4         5
+    %define     RDO_SCALE_8         7
+    %define     RDO_SCALE_16        9
+    %define     RDO_SCALE_32        11
 %else
     %error Unsupported BIT_DEPTH!
 %endif
@@ -6415,6 +6427,111 @@ cglobal idct4, 3, 4, 6
     movhps          [r1 + 2 * r2], xm0
     movhps          [r1 + r3], xm1
     RET
+
+%macro NONPSY_RDO_QUANT_ALL 2
+    mov             r4d,        %1
+    vpxor           m3,         m3
+    vpxor           m4,         m4
+.loop:
+    vpmovsxwq       m1,         [r0]
+    vpmullq         m1,         m1
+    vpsllq          m1,         %2
+    paddq           m4,         m1
+    movu            [r1],       m1
+    add             r0,         16
+    add             r1,         64
+    dec             r4d
+    jnz             .loop
+
+    vextracti32x8  ym2,         m4, 1
+    paddq          ym4,         ym2
+    vextracti32x4  xm2,         m4, 1
+    paddq          xm4,         xm2
+    punpckhqdq     xm2,         xm4, xm3
+    paddq          xm4,         xm2
+    movq           xm6,         [r2]
+    movq           xm7,         [r3]
+    paddq          xm6,         xm4
+    paddq          xm7,         xm4
+    movq           [r2],        xm6
+    movq           [r3],        xm7
+    RET
+%endmacro
+
+INIT_ZMM avx512
+cglobal nonPsyRdoQuantAll4, 4, 5, 8
+    NONPSY_RDO_QUANT_ALL 2, RDO_SCALE_4
+
+INIT_ZMM avx512
+cglobal nonPsyRdoQuantAll8, 4, 5, 8
+    NONPSY_RDO_QUANT_ALL 8, RDO_SCALE_8
+
+INIT_ZMM avx512
+cglobal nonPsyRdoQuantAll16, 4, 5, 8
+    NONPSY_RDO_QUANT_ALL 32, RDO_SCALE_16
+
+INIT_ZMM avx512
+cglobal nonPsyRdoQuantAll32, 4, 5, 8
+    NONPSY_RDO_QUANT_ALL 128, RDO_SCALE_32
+
+%macro PSY_RDO_QUANT_ALL 3
+%if WIN64
+    mov             r5,         r5m
+%endif
+    mov             r6d,        %1
+    vpbroadcastq    m12,        [r5]
+    vpxor           m3,         m3
+    vpxor           m4,         m4
+.loop:
+    vpmovsxwq       m6,         [r0]
+    vpmovsxwq       m7,         [r1]
+    psubq           m7,         m6
+
+    vpmullq         m8,         m6, m6
+    vpsllq          m8,         %2
+
+    vpmullq         m9,         m7, m12
+    vpsraq          m9,         %3
+
+    psubq           m8,         m9
+    paddq           m4,         m8
+    movu            [r2],       m8
+    add             r0,         16
+    add             r1,         16
+    add             r2,         64
+    dec             r6d
+    jnz             .loop
+
+    vextracti32x8  ym2,         m4, 1
+    paddq          ym4,         ym2
+    vextracti32x4  xm2,         m4, 1
+    paddq          xm4,         xm2
+    punpckhqdq     xm2,         xm4, xm3
+    paddq          xm4,         xm2
+    movq           xm0,         [r3]
+    movq           xm1,         [r4]
+    paddq          xm0,         xm4
+    paddq          xm1,         xm4
+    movq           [r3],        xm0
+    movq           [r4],        xm1
+    RET
+%endmacro
+
+INIT_ZMM avx512
+cglobal psyRdoQuantAll4, 6, 7, 13
+    PSY_RDO_QUANT_ALL 2, RDO_SCALE_4, RDO_MAX_4
+
+INIT_ZMM avx512
+cglobal psyRdoQuantAll8, 6, 7, 13
+    PSY_RDO_QUANT_ALL 8, RDO_SCALE_8, RDO_MAX_8
+
+INIT_ZMM avx512
+cglobal psyRdoQuantAll16, 6, 7, 13
+    PSY_RDO_QUANT_ALL 32, RDO_SCALE_16, RDO_MAX_16
+
+INIT_ZMM avx512
+cglobal psyRdoQuantAll32, 6, 7, 13
+    PSY_RDO_QUANT_ALL 128, RDO_SCALE_32, RDO_MAX_32
 
 ;static void nonPsyRdoQuant_c(int16_t *m_resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, uint32_t blkPos)
 ;{

--- a/source/common/x86/dct8.h
+++ b/source/common/x86/dct8.h
@@ -40,6 +40,7 @@ FUNCDEF_TU_S2(void, nonPsyRdoQuant, avx2, int16_t *m_resiDctCoeff, int64_t *cost
 FUNCDEF_TU_S2(void, psyRdoQuant_1p, avx2, int16_t* m_resiDctCoeff,  int64_t* costUncoded, int64_t* totalUncodedCost, int64_t* totalRdCost,  uint32_t blkPos);
 FUNCDEF_TU_S2(void, psyRdoQuant_2p, avx2, int16_t* m_resiDctCoeff, int16_t* m_fencDctCoeff, int64_t* costUncoded, int64_t* totalUncodedCost, int64_t* totalRdCost, int64_t *psyScale, uint32_t blkPos);
 FUNCDEF_TU_S2(void, nonPsyRdoQuantAll, avx512, const int16_t *m_resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost);
+FUNCDEF_TU_S2(void, psyRdoQuantAll, avx2, const int16_t *m_resiDctCoeff, const int16_t *m_fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, const int64_t *psyScale);
 FUNCDEF_TU_S2(void, psyRdoQuantAll, avx512, const int16_t *m_resiDctCoeff, const int16_t *m_fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, const int64_t *psyScale);
 
 void PFX(dst4_ssse3)(const int16_t* src, int16_t* dst, intptr_t srcStride);

--- a/source/common/x86/dct8.h
+++ b/source/common/x86/dct8.h
@@ -39,6 +39,8 @@ FUNCDEF_TU_S2(void, psyRdoQuant, avx512, int16_t* m_resiDctCoeff, int16_t* m_fen
 FUNCDEF_TU_S2(void, nonPsyRdoQuant, avx2, int16_t *m_resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, uint32_t blkPos);
 FUNCDEF_TU_S2(void, psyRdoQuant_1p, avx2, int16_t* m_resiDctCoeff,  int64_t* costUncoded, int64_t* totalUncodedCost, int64_t* totalRdCost,  uint32_t blkPos);
 FUNCDEF_TU_S2(void, psyRdoQuant_2p, avx2, int16_t* m_resiDctCoeff, int16_t* m_fencDctCoeff, int64_t* costUncoded, int64_t* totalUncodedCost, int64_t* totalRdCost, int64_t *psyScale, uint32_t blkPos);
+FUNCDEF_TU_S2(void, nonPsyRdoQuantAll, avx512, int16_t *m_resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost);
+FUNCDEF_TU_S2(void, psyRdoQuantAll, avx512, int16_t *m_resiDctCoeff, int16_t *m_fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, int64_t *psyScale);
 
 void PFX(dst4_ssse3)(const int16_t* src, int16_t* dst, intptr_t srcStride);
 void PFX(dst4_sse2)(const int16_t* src, int16_t* dst, intptr_t srcStride);

--- a/source/common/x86/dct8.h
+++ b/source/common/x86/dct8.h
@@ -39,8 +39,8 @@ FUNCDEF_TU_S2(void, psyRdoQuant, avx512, int16_t* m_resiDctCoeff, int16_t* m_fen
 FUNCDEF_TU_S2(void, nonPsyRdoQuant, avx2, int16_t *m_resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, uint32_t blkPos);
 FUNCDEF_TU_S2(void, psyRdoQuant_1p, avx2, int16_t* m_resiDctCoeff,  int64_t* costUncoded, int64_t* totalUncodedCost, int64_t* totalRdCost,  uint32_t blkPos);
 FUNCDEF_TU_S2(void, psyRdoQuant_2p, avx2, int16_t* m_resiDctCoeff, int16_t* m_fencDctCoeff, int64_t* costUncoded, int64_t* totalUncodedCost, int64_t* totalRdCost, int64_t *psyScale, uint32_t blkPos);
-FUNCDEF_TU_S2(void, nonPsyRdoQuantAll, avx512, int16_t *m_resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost);
-FUNCDEF_TU_S2(void, psyRdoQuantAll, avx512, int16_t *m_resiDctCoeff, int16_t *m_fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, int64_t *psyScale);
+FUNCDEF_TU_S2(void, nonPsyRdoQuantAll, avx512, const int16_t *m_resiDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost);
+FUNCDEF_TU_S2(void, psyRdoQuantAll, avx512, const int16_t *m_resiDctCoeff, const int16_t *m_fencDctCoeff, int64_t *costUncoded, int64_t *totalUncodedCost, int64_t *totalRdCost, const int64_t *psyScale);
 
 void PFX(dst4_ssse3)(const int16_t* src, int16_t* dst, intptr_t srcStride);
 void PFX(dst4_sse2)(const int16_t* src, int16_t* dst, intptr_t srcStride);

--- a/source/common/x86/pixel-util8.asm
+++ b/source/common/x86/pixel-util8.asm
@@ -8251,12 +8251,8 @@ cglobal scanPosLast, 7,11,6
     pmovmskb    r6d, m2
     mov         [r3 + r9 * 2], r6w
 
-    ; get non-zero number, POPCNT is faster
-    pabsb       m2, m2
-    psadbw      m2, m4
-    movhlps     m3, m2
-    paddd       m2, m3
-    movd        r6d, m2
+    ; Count the nonzero flags already extracted above.
+    popcnt      r6d, r6d
     mov         [r4 + r9], r6b
 
     inc         r9d

--- a/source/common/x86/pixel-util8.asm
+++ b/source/common/x86/pixel-util8.asm
@@ -1280,97 +1280,35 @@ cglobal nquant, 3,5,7
     RET
 %if ARCH_X86_64 == 1
 INIT_ZMM avx512
-cglobal nquant, 3,5,22
-%if UNIX64 == 0
-    vpbroadcastd m4, r4m
-%else ; Mac
-    movd         xm4, r4m
-    vpbroadcastd  m4, xm4
-%endif
-
-    vbroadcasti32x8  m6, [pw_1]
-    mov         r4d, r5m
-    pxor         m5, m5
-    movd        xm3, r3m
-    sub         r4d, 16
-    je          .coeff16
-    add         r4d, 16
-    shr         r4d, 5
-    jmp         .loop
-
-.coeff16:
-    pmovsxwd         m16, [r0]
-    pabsd            m17, m16
-    pmulld           m17, [r1]
-    paddd            m17, m4
-    psrad            m17, xm3
-
-    vextracti64x4   ym19,  m17, 1
-    vextracti64x4   ym20,  m16, 1
-    psignd          ym17, ym16
-    psignd          ym19, ym20
-    packssdw        ym17, ym19
-    vpermq          ym17, ym17, q3120
-    pabsw           ym17, ym17
-    movu            [r2], ym17
-    pminuw          ym17, ym6
-    paddw           ym5,  ym17
-    pxor            m0,    m0
-    psadbw          ym5,  ym0
-    vextracti128    xm0,  ym5, 1
-    paddd           xm5,  xm0
-    pshufd          xm0,  xm5, 2
-    paddd           xm5,  xm0
-    movd            eax,  xm5
-    RET
+cglobal nquant, 3,6,5
+    movd             xm3, r3m
+    vpbroadcastd      m4, r4m
+    mov              r4d, r5m
+    xor              r3d, r3d
 
 .loop:
-    pmovsxwd         m16,  [r0]
-    pabsd            m17,  m16
-    pmulld           m17,  [r1]
-    paddd            m17,  m4
-    psrad            m17,  xm3
-    vextracti64x4   ym19,  m17, 1
-    vextracti64x4   ym20,  m16, 1
-    psignd          ym17, ym16
-    psignd          ym19, ym20
-    packssdw        ym17, ym19
+    pmovsxwd          m0, [r0]
+    pabsd             m1, m0
+    pmulld            m1, [r1]
+    paddd             m1, m4
+    psrad             m1, xm3
+    psrad             m0, 31
+    pxor              m1, m0
+    psubd             m1, m0
+    vpmovsdw         ym1, m1
+    pabsw            ym1, ym1
+    movu            [r2], ym1
+    vptestmw          k1, ym1, ym1
+    kmovw            r5d, k1
+    popcnt           r5d, r5d
+    add              r3d, r5d
 
-    pmovsxwd         m16, [r0 + mmsize/2]
-    pabsd            m18, m16
-    pmulld           m18, [r1 + mmsize]
-    paddd            m18,  m4
-    psrad            m18, xm3
-    vextracti64x4   ym21,  m18, 1
-    vextracti64x4   ym20,  m16, 1
-    psignd          ym18, ym16
-    psignd          ym21, ym20
-    packssdw        ym18, ym21
-    vinserti64x4     m17,  m17, ym18, 1
-    vpermq           m17,  m17, q3120
-
-    pabsw            m17, m17
-    movu            [r2], m17
-
-    add               r0, mmsize
-    add               r1, mmsize * 2
-    add               r2, mmsize
-
-    pminuw           m17,  m6
-    paddw             m5, m17
-
-    dec         r4d
-    jnz         .loop
-
-    pxor             m0,  m0
-    psadbw           m5,  m0
-    vextracti32x8   ym1,  m5, 1
-    paddd           ym5, ym1
-    vextracti64x2   xm1,  m5, 1
-    paddd           xm5, xm1
-    pshufd          xm1, xm5, 2
-    paddd           xm5, xm1
-    movd            eax, xm5
+    add               r0, 32
+    add               r1, 64
+    add               r2, 32
+    sub              r4d, 16
+    jnz            .loop
+    mov              eax, r3d
     RET
 %endif ; ARCH_X86_64 == 1
 

--- a/source/test/mbdstharness.cpp
+++ b/source/test/mbdstharness.cpp
@@ -410,13 +410,15 @@ bool MBDstHarness::check_psyRdoQuantAll_primitive(psyRdoQuantAll_t ref, psyRdoQu
     ALIGN_VAR_64(int64_t, refDest[MAX_TU_SIZE]);
     ALIGN_VAR_64(int64_t, optDest[MAX_TU_SIZE]);
 
+    const int64_t scales[] = { 0, INT32_MAX, 1LL << 31, (1LL << 32) + 1, (1LL << 36) - 1 };
+    const int numScales = sizeof(scales) / sizeof(scales[0]);
     for (int i = 0, j = 0; i < ITERS; i++, j += INCR)
     {
         int64_t totalRdCostRef = rand();
         int64_t totalUncodedCostRef = rand();
         int64_t totalRdCostOpt = totalRdCostRef;
         int64_t totalUncodedCostOpt = totalUncodedCostRef;
-        int64_t psyScale = rand();
+        int64_t psyScale = i % 2 ? scales[(i / 2) % numScales] : rand();
         int index = rand() % TEST_CASES;
 
         memset(refDest, 0, sizeof(refDest));

--- a/source/test/mbdstharness.cpp
+++ b/source/test/mbdstharness.cpp
@@ -376,6 +376,64 @@ bool MBDstHarness::check_psyRdoQuant_primitive(psyRdoQuant_t ref, psyRdoQuant_t 
 
     return true;
 }
+
+bool MBDstHarness::check_nonPsyRdoQuantAll_primitive(nonPsyRdoQuantAll_t ref, nonPsyRdoQuantAll_t opt, int numCoeff)
+{
+    ALIGN_VAR_64(int64_t, refDest[MAX_TU_SIZE]);
+    ALIGN_VAR_64(int64_t, optDest[MAX_TU_SIZE]);
+
+    for (int i = 0, j = 0; i < ITERS; i++, j += INCR)
+    {
+        int64_t totalRdCostRef = rand();
+        int64_t totalUncodedCostRef = rand();
+        int64_t totalRdCostOpt = totalRdCostRef;
+        int64_t totalUncodedCostOpt = totalUncodedCostRef;
+        int index = rand() % TEST_CASES;
+
+        memset(refDest, 0, sizeof(refDest));
+        memset(optDest, 0, sizeof(optDest));
+        ref(short_test_buff[index] + j, refDest, &totalUncodedCostRef, &totalRdCostRef);
+        checked(opt, short_test_buff[index] + j, optDest, &totalUncodedCostOpt, &totalRdCostOpt);
+
+        if (memcmp(refDest, optDest, numCoeff * sizeof(*refDest)) ||
+            totalUncodedCostRef != totalUncodedCostOpt || totalRdCostRef != totalRdCostOpt)
+            return false;
+
+        reportfail();
+    }
+
+    return true;
+}
+
+bool MBDstHarness::check_psyRdoQuantAll_primitive(psyRdoQuantAll_t ref, psyRdoQuantAll_t opt, int numCoeff)
+{
+    ALIGN_VAR_64(int64_t, refDest[MAX_TU_SIZE]);
+    ALIGN_VAR_64(int64_t, optDest[MAX_TU_SIZE]);
+
+    for (int i = 0, j = 0; i < ITERS; i++, j += INCR)
+    {
+        int64_t totalRdCostRef = rand();
+        int64_t totalUncodedCostRef = rand();
+        int64_t totalRdCostOpt = totalRdCostRef;
+        int64_t totalUncodedCostOpt = totalUncodedCostRef;
+        int64_t psyScale = rand();
+        int index = rand() % TEST_CASES;
+
+        memset(refDest, 0, sizeof(refDest));
+        memset(optDest, 0, sizeof(optDest));
+        ref(short_test_buff[index] + j, short_test_buff1[index] + j, refDest, &totalUncodedCostRef, &totalRdCostRef, &psyScale);
+        checked(opt, short_test_buff[index] + j, short_test_buff1[index] + j, optDest, &totalUncodedCostOpt, &totalRdCostOpt, &psyScale);
+
+        if (memcmp(refDest, optDest, numCoeff * sizeof(*refDest)) ||
+            totalUncodedCostRef != totalUncodedCostOpt || totalRdCostRef != totalRdCostOpt)
+            return false;
+
+        reportfail();
+    }
+
+    return true;
+}
+
 bool MBDstHarness::check_psyRdoQuant_primitive_avx2(psyRdoQuant_t1 ref, psyRdoQuant_t1 opt)
 {
     int j = 0;
@@ -576,6 +634,22 @@ bool MBDstHarness::testCorrectness(const EncoderPrimitives& ref, const EncoderPr
                 printf("psyRdoQuant[%dx%d]: Failed!\n", 4 << i, 4 << i);
                 return false;
             }
+        }
+    }
+    for (int i = 0; i < NUM_TR_SIZE; i++)
+    {
+        int numCoeff = 1 << (2 * (i + 2));
+        if (opt.cu[i].nonPsyRdoQuantAll &&
+            !check_nonPsyRdoQuantAll_primitive(ref.cu[i].nonPsyRdoQuantAll, opt.cu[i].nonPsyRdoQuantAll, numCoeff))
+        {
+            printf("nonPsyRdoQuantAll[%dx%d]: Failed!\n", 4 << i, 4 << i);
+            return false;
+        }
+        if (opt.cu[i].psyRdoQuantAll &&
+            !check_psyRdoQuantAll_primitive(ref.cu[i].psyRdoQuantAll, opt.cu[i].psyRdoQuantAll, numCoeff))
+        {
+            printf("psyRdoQuantAll[%dx%d]: Failed!\n", 4 << i, 4 << i);
+            return false;
         }
     }
     for (int i = 0; i < NUM_TR_SIZE; i++)

--- a/source/test/mbdstharness.h
+++ b/source/test/mbdstharness.h
@@ -65,6 +65,8 @@ protected:
     bool check_dequant_primitive(dequant_normal_t ref, dequant_normal_t opt);
     bool check_nonPsyRdoQuant_primitive(nonPsyRdoQuant_t ref, nonPsyRdoQuant_t opt);
     bool check_psyRdoQuant_primitive(psyRdoQuant_t ref, psyRdoQuant_t opt);
+    bool check_nonPsyRdoQuantAll_primitive(nonPsyRdoQuantAll_t ref, nonPsyRdoQuantAll_t opt, int numCoeff);
+    bool check_psyRdoQuantAll_primitive(psyRdoQuantAll_t ref, psyRdoQuantAll_t opt, int numCoeff);
     bool check_quant_primitive(quant_t ref, quant_t opt);
     bool check_nquant_primitive(nquant_t ref, nquant_t opt);
     bool check_dct_primitive(dct_t ref, dct_t opt, intptr_t width);


### PR DESCRIPTION
Reduce redundant work in Quant::rdoQuant():

- Cache the scan tables, scan type, the first significance context, and the sign-hiding flag before coefficient processing.
- Stop both coefficient passes at the last non-zero coefficient and remove unused tail cost initialization. Coefficients after this position only contribute uncoded distortion.
- Keep the current uncoded distortion in a local value, store it once for later passes, and reuse the local value in the current pass.
- Remove the coefficient group cost initialization because every path that reads the value assigns it first.
- Skip per-coefficient significance-cost and rate-delta setup for quantized-empty coefficient groups. Later passes skip this data for empty groups.
- Compute uncoded distortion for all transform coefficients in one C or SIMD primitive, with AVX2 psy costs and AVX-512 psy and non-psy costs, and reuse the stored costs during coefficient processing.
- Compute the source DCT only for non-empty quantized blocks and keep one cache entry per transform size for reuse across prediction candidates.
- Count non-zero coefficients from the flag mask already produced by scanPosLast.
- Accumulate C batch costs locally and update each total once after the coefficient loop.
- Process AVX-512 RDOQ quantization in one sixteen-coefficient loop and count non-zero lanes from the vector mask.
