### PR TITLE
intra: Reuse per-PU candidate data

### DIFF
--- a/source/encoder/search.cpp
+++ b/source/encoder/search.cpp
@@ -643,7 +643,7 @@ void Search::codeCoeffQTChroma(const CUData& cu, uint32_t tuDepth, uint32_t absP
     }
 }
 
-void Search::codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, bool bAllowSplit, bool bUseCachedIntraData, Cost& outCost, const uint32_t depthRange[2])
+void Search::codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, bool bAllowSplit, bool bUseCachedIntraData, const IntraLumaQTCache* fullResult, Cost& outCost, const uint32_t depthRange[2])
 {
     CUData& cu = mode.cu;
     uint32_t fullDepth  = cuGeom.depth + tuDepth;
@@ -667,7 +667,26 @@ void Search::codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth,
     pixel*   reconQt = m_rqt[qtLayer].reconQtYuv.getLumaAddr(absPartIdx);
     uint32_t reconQtStride = m_rqt[qtLayer].reconQtYuv.m_size;
 
-    if (mightNotSplit)
+    if (fullResult)
+    {
+        X265_CHECK(mightNotSplit && bUseCachedIntraData, "invalid cached intra TU\n");
+
+        if (mightSplit)
+            m_entropyCoder.store(m_rqt[fullDepth].rqtRoot);
+
+        uint32_t lumaPredMode = cu.m_lumaIntraDir[absPartIdx];
+        pixel* pred = mode.predYuv.getLumaAddr(absPartIdx);
+        uint32_t stride = mode.fencYuv->m_size;
+        predIntraLumaAng(lumaPredMode, pred, stride, log2TrSize);
+
+        bCBF = fullResult->cbf;
+        cu.setTransformSkipSubParts(0, TEXT_LUMA, absPartIdx, fullDepth);
+        cu.setTUDepthSubParts(tuDepth, absPartIdx, fullDepth);
+        cu.setCbfSubParts(bCBF, TEXT_LUMA, absPartIdx, fullDepth);
+        fullCost = fullResult->cost;
+        m_entropyCoder.load(mode.contexts);
+    }
+    else if (mightNotSplit)
     {
         if (mightSplit)
             m_entropyCoder.store(m_rqt[fullDepth].rqtRoot);
@@ -797,7 +816,7 @@ void Search::codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth,
             if (checkTransformSkip)
                 codeIntraLumaTSkip(mode, cuGeom, tuDepth + 1, qPartIdx, false, splitCost);
             else
-                codeIntraLumaQT(mode, cuGeom, tuDepth + 1, qPartIdx, bAllowSplit, false, splitCost, depthRange);
+                codeIntraLumaQT(mode, cuGeom, tuDepth + 1, qPartIdx, bAllowSplit, false, NULL, splitCost, depthRange);
 
             cbf |= cu.getCbf(qPartIdx, TEXT_LUMA, tuDepth + 1);
         }
@@ -842,7 +861,13 @@ void Search::codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth,
     PicYuv*  reconPic = m_frame->m_reconPic[0];
     pixel*   picReconY = reconPic->getLumaAddr(cu.m_cuAddr, cuGeom.absPartIdx + absPartIdx);
     intptr_t picStride = reconPic->m_stride;
-    primitives.cu[sizeIdx].copy_pp(picReconY, picStride, reconQt, reconQtStride);
+    if (fullResult)
+    {
+        const pixel* cachedRecon = mode.reconYuv.getLumaAddr(absPartIdx);
+        primitives.cu[sizeIdx].copy_pp(picReconY, picStride, cachedRecon, mode.reconYuv.m_size);
+    }
+    else
+        primitives.cu[sizeIdx].copy_pp(picReconY, picStride, reconQt, reconQtStride);
 
     outCost.rdcost     += fullCost.rdcost;
     outCost.distortion += fullCost.distortion;
@@ -1817,7 +1842,7 @@ void Search::encodeIntraInInter(Mode& intraMode, const CUGeom& cuGeom)
     m_entropyCoder.load(m_rqt[cuGeom.depth].cur);
 
     Cost icosts;
-    codeIntraLumaQT(intraMode, cuGeom, 0, 0, false, false, icosts, tuDepthRange);
+    codeIntraLumaQT(intraMode, cuGeom, 0, 0, false, false, NULL, icosts, tuDepthRange);
     extractIntraResultQT(cu, *reconYuv, 0, 0);
 
     intraMode.lumaDistortion = icosts.distortion;
@@ -1880,6 +1905,8 @@ sse_t Search::estIntraPredQT(Mode &intraMode, const CUGeom& cuGeom, const uint32
     {
         uint32_t bmode = 0;
         bool bUseCachedIntraData = false;
+        bool bBestFullResult = false;
+        IntraLumaQTCache bestFullResult;
 
         if (intraMode.cu.m_lumaIntraDir[puIdx] != (uint8_t)ALL_IDX)
             bmode = intraMode.cu.m_lumaIntraDir[puIdx];
@@ -2004,8 +2031,21 @@ sse_t Search::estIntraPredQT(Mode &intraMode, const CUGeom& cuGeom, const uint32
                 if (checkTransformSkip)
                     codeIntraLumaTSkip(intraMode, cuGeom, initTuDepth, absPartIdx, bUseCachedIntraData, icosts);
                 else
-                    codeIntraLumaQT(intraMode, cuGeom, initTuDepth, absPartIdx, false, bUseCachedIntraData, icosts, depthRange);
-                COPY2_IF_LT(bcost, icosts.rdcost, bmode, rdModeList[i]);
+                    codeIntraLumaQT(intraMode, cuGeom, initTuDepth, absPartIdx, false, bUseCachedIntraData, NULL, icosts, depthRange);
+
+                if (icosts.rdcost < bcost)
+                {
+                    bcost = icosts.rdcost;
+                    bmode = rdModeList[i];
+                    bBestFullResult = !checkTransformSkip && cu.m_tuDepth[absPartIdx] == initTuDepth;
+                    if (bBestFullResult)
+                    {
+                        bestFullResult.cost = icosts;
+                        bestFullResult.cbf = cu.m_cbf[0][absPartIdx];
+                        extractIntraResultQT(cu, *reconYuv, initTuDepth, absPartIdx);
+                        m_entropyCoder.store(intraMode.contexts);
+                    }
+                }
             }
         }
 
@@ -2019,10 +2059,11 @@ sse_t Search::estIntraPredQT(Mode &intraMode, const CUGeom& cuGeom, const uint32
         if (checkTransformSkip)
             codeIntraLumaTSkip(intraMode, cuGeom, initTuDepth, absPartIdx, bUseCachedIntraData, icosts);
         else
-            codeIntraLumaQT(intraMode, cuGeom, initTuDepth, absPartIdx, true, bUseCachedIntraData, icosts, depthRange);
+            codeIntraLumaQT(intraMode, cuGeom, initTuDepth, absPartIdx, true, bUseCachedIntraData, bBestFullResult ? &bestFullResult : NULL, icosts, depthRange);
         totalDistortion += icosts.distortion;
 
-        extractIntraResultQT(cu, *reconYuv, initTuDepth, absPartIdx);
+        if (!bBestFullResult || cu.m_tuDepth[absPartIdx] != initTuDepth)
+            extractIntraResultQT(cu, *reconYuv, initTuDepth, absPartIdx);
 
         // set reconstruction for next intra prediction blocks
         if (puIdx != numPU - 1)

--- a/source/encoder/search.cpp
+++ b/source/encoder/search.cpp
@@ -643,7 +643,7 @@ void Search::codeCoeffQTChroma(const CUData& cu, uint32_t tuDepth, uint32_t absP
     }
 }
 
-void Search::codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, bool bAllowSplit, Cost& outCost, const uint32_t depthRange[2])
+void Search::codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, bool bAllowSplit, bool bUseCachedIntraData, Cost& outCost, const uint32_t depthRange[2])
 {
     CUData& cu = mode.cu;
     uint32_t fullDepth  = cuGeom.depth + tuDepth;
@@ -677,11 +677,13 @@ void Search::codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth,
         int16_t* residual = m_rqt[cuGeom.depth].tmpResiYuv.getLumaAddr(absPartIdx);
         uint32_t stride   = mode.fencYuv->m_size;
 
-        // init availability pattern
         uint32_t lumaPredMode = cu.m_lumaIntraDir[absPartIdx];
-        IntraNeighbors intraNeighbors;
-        initIntraNeighbors(cu, absPartIdx, tuDepth, true, &intraNeighbors);
-        initAdiPattern(cu, cuGeom, absPartIdx, intraNeighbors, lumaPredMode);
+        if (!bUseCachedIntraData)
+        {
+            IntraNeighbors intraNeighbors;
+            initIntraNeighbors(cu, absPartIdx, tuDepth, true, &intraNeighbors);
+            initAdiPattern(cu, cuGeom, absPartIdx, intraNeighbors, lumaPredMode);
+        }
 
         // get prediction signal
         predIntraLumaAng(lumaPredMode, pred, stride, log2TrSize);
@@ -693,7 +695,7 @@ void Search::codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth,
         coeff_t* coeffY       = m_rqt[qtLayer].coeffRQT[0] + coeffOffsetY;
 
         // store original entropy coding status
-        if (bEnableRDOQ)
+        if (bEnableRDOQ && !bUseCachedIntraData)
             m_entropyCoder.estBit(m_entropyCoder.m_estBitsSbac, log2TrSize, true);
         primitives.cu[sizeIdx].calcresidual[stride % 64 == 0](fenc, pred, residual, stride);
 
@@ -793,9 +795,9 @@ void Search::codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth,
         for (uint32_t qIdx = 0, qPartIdx = absPartIdx; qIdx < 4; ++qIdx, qPartIdx += qNumParts)
         {
             if (checkTransformSkip)
-                codeIntraLumaTSkip(mode, cuGeom, tuDepth + 1, qPartIdx, splitCost);
+                codeIntraLumaTSkip(mode, cuGeom, tuDepth + 1, qPartIdx, false, splitCost);
             else
-                codeIntraLumaQT(mode, cuGeom, tuDepth + 1, qPartIdx, bAllowSplit, splitCost, depthRange);
+                codeIntraLumaQT(mode, cuGeom, tuDepth + 1, qPartIdx, bAllowSplit, false, splitCost, depthRange);
 
             cbf |= cu.getCbf(qPartIdx, TEXT_LUMA, tuDepth + 1);
         }
@@ -848,7 +850,7 @@ void Search::codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth,
     outCost.energy     += fullCost.energy;
 }
 
-void Search::codeIntraLumaTSkip(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, Cost& outCost)
+void Search::codeIntraLumaTSkip(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, bool bUseCachedIntraData, Cost& outCost)
 {
     uint32_t fullDepth = cuGeom.depth + tuDepth;
     uint32_t log2TrSize = cuGeom.log2CUSize - tuDepth;
@@ -872,11 +874,13 @@ void Search::codeIntraLumaTSkip(Mode& mode, const CUGeom& cuGeom, uint32_t tuDep
     uint32_t stride = fencYuv->m_size;
     uint32_t sizeIdx = log2TrSize - 2;
 
-    // init availability pattern
     uint32_t lumaPredMode = cu.m_lumaIntraDir[absPartIdx];
-    IntraNeighbors intraNeighbors;
-    initIntraNeighbors(cu, absPartIdx, tuDepth, true, &intraNeighbors);
-    initAdiPattern(cu, cuGeom, absPartIdx, intraNeighbors, lumaPredMode);
+    if (!bUseCachedIntraData)
+    {
+        IntraNeighbors intraNeighbors;
+        initIntraNeighbors(cu, absPartIdx, tuDepth, true, &intraNeighbors);
+        initAdiPattern(cu, cuGeom, absPartIdx, intraNeighbors, lumaPredMode);
+    }
 
     // get prediction signal
     predIntraLumaAng(lumaPredMode, pred, stride, log2TrSize);
@@ -892,7 +896,7 @@ void Search::codeIntraLumaTSkip(Mode& mode, const CUGeom& cuGeom, uint32_t tuDep
     // store original entropy coding status
     m_entropyCoder.store(m_rqt[fullDepth].rqtRoot);
 
-    if (bEnableRDOQ)
+    if (bEnableRDOQ && !bUseCachedIntraData)
         m_entropyCoder.estBit(m_entropyCoder.m_estBitsSbac, log2TrSize, true);
 
     int checkTransformSkip = 1;
@@ -1813,7 +1817,7 @@ void Search::encodeIntraInInter(Mode& intraMode, const CUGeom& cuGeom)
     m_entropyCoder.load(m_rqt[cuGeom.depth].cur);
 
     Cost icosts;
-    codeIntraLumaQT(intraMode, cuGeom, 0, 0, false, icosts, tuDepthRange);
+    codeIntraLumaQT(intraMode, cuGeom, 0, 0, false, false, icosts, tuDepthRange);
     extractIntraResultQT(cu, *reconYuv, 0, 0);
 
     intraMode.lumaDistortion = icosts.distortion;
@@ -1875,6 +1879,7 @@ sse_t Search::estIntraPredQT(Mode &intraMode, const CUGeom& cuGeom, const uint32
     for (uint32_t puIdx = 0; puIdx < numPU; puIdx++, absPartIdx += qNumParts)
     {
         uint32_t bmode = 0;
+        bool bUseCachedIntraData = false;
 
         if (intraMode.cu.m_lumaIntraDir[puIdx] != (uint8_t)ALL_IDX)
             bmode = intraMode.cu.m_lumaIntraDir[puIdx];
@@ -1972,6 +1977,15 @@ sse_t Search::estIntraPredQT(Mode &intraMode, const CUGeom& cuGeom, const uint32
                     if ((modeCosts[mode] < paddedBcost) || ((uint32_t)mode == mpmModes[0])) 
                         /* choose for R-D analysis only if this mode passes cost threshold or matches MPM[0] */
                         updateCandList(mode, modeCosts[mode], maxCandCount, rdModeList, candCostList);
+
+                /* Reference samples and RDOQ bit estimates are invariant across
+                 * the RDO candidates for this PU. */
+                if (m_param->rdoqLevel && log2TrSize <= 5)
+                {
+                    m_entropyCoder.load(m_rqt[depth].cur);
+                    m_entropyCoder.estBit(m_entropyCoder.m_estBitsSbac, log2TrSize, true);
+                }
+                bUseCachedIntraData = log2TrSize <= 5;
             }
 
             /* measure best candidates using simple RDO (no TU splits) */
@@ -1988,9 +2002,9 @@ sse_t Search::estIntraPredQT(Mode &intraMode, const CUGeom& cuGeom, const uint32
 
                 Cost icosts;
                 if (checkTransformSkip)
-                    codeIntraLumaTSkip(intraMode, cuGeom, initTuDepth, absPartIdx, icosts);
+                    codeIntraLumaTSkip(intraMode, cuGeom, initTuDepth, absPartIdx, bUseCachedIntraData, icosts);
                 else
-                    codeIntraLumaQT(intraMode, cuGeom, initTuDepth, absPartIdx, false, icosts, depthRange);
+                    codeIntraLumaQT(intraMode, cuGeom, initTuDepth, absPartIdx, false, bUseCachedIntraData, icosts, depthRange);
                 COPY2_IF_LT(bcost, icosts.rdcost, bmode, rdModeList[i]);
             }
         }
@@ -2003,9 +2017,9 @@ sse_t Search::estIntraPredQT(Mode &intraMode, const CUGeom& cuGeom, const uint32
 
         Cost icosts;
         if (checkTransformSkip)
-            codeIntraLumaTSkip(intraMode, cuGeom, initTuDepth, absPartIdx, icosts);
+            codeIntraLumaTSkip(intraMode, cuGeom, initTuDepth, absPartIdx, bUseCachedIntraData, icosts);
         else
-            codeIntraLumaQT(intraMode, cuGeom, initTuDepth, absPartIdx, true, icosts, depthRange);
+            codeIntraLumaQT(intraMode, cuGeom, initTuDepth, absPartIdx, true, bUseCachedIntraData, icosts, depthRange);
         totalDistortion += icosts.distortion;
 
         extractIntraResultQT(cu, *reconYuv, initTuDepth, absPartIdx);

--- a/source/encoder/search.h
+++ b/source/encoder/search.h
@@ -447,9 +447,9 @@ protected:
     bool     splitTU(Mode& mode, const CUGeom& cuGeom, uint32_t absPartIdx, uint32_t tuDepth, ShortYuv& resiYuv, Cost& splitCost, const uint32_t depthRange[2], int32_t splitMore);
     void     estimateResidualQT(Mode& mode, const CUGeom& cuGeom, uint32_t absPartIdx, uint32_t depth, ShortYuv& resiYuv, Cost& costs, const uint32_t depthRange[2], int32_t splitMore = -1);
 
-    // generate prediction, generate residual and recon. if bAllowSplit, find optimal RQT splits
-    void     codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, bool bAllowSplit, Cost& costs, const uint32_t depthRange[2]);
-    void     codeIntraLumaTSkip(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, Cost& costs);
+    // generate prediction, residual, and reconstruction; reuse per-PU data when the caller has prepared it
+    void     codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, bool bAllowSplit, bool bUseCachedIntraData, Cost& costs, const uint32_t depthRange[2]);
+    void     codeIntraLumaTSkip(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, bool bUseCachedIntraData, Cost& costs);
     void     extractIntraResultQT(CUData& cu, Yuv& reconYuv, uint32_t tuDepth, uint32_t absPartIdx);
 
     // generate chroma prediction, generate residual and recon

--- a/source/encoder/search.h
+++ b/source/encoder/search.h
@@ -435,6 +435,12 @@ protected:
         Cost() { rdcost = 0; bits = 0; distortion = 0; energy = 0; }
     };
 
+    struct IntraLumaQTCache
+    {
+        Cost cost;
+        uint32_t cbf;
+    };
+
     struct TUInfoCache
     {
         Cost cost[NUM_SUBPART];
@@ -448,7 +454,7 @@ protected:
     void     estimateResidualQT(Mode& mode, const CUGeom& cuGeom, uint32_t absPartIdx, uint32_t depth, ShortYuv& resiYuv, Cost& costs, const uint32_t depthRange[2], int32_t splitMore = -1);
 
     // generate prediction, residual, and reconstruction; reuse per-PU data when the caller has prepared it
-    void     codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, bool bAllowSplit, bool bUseCachedIntraData, Cost& costs, const uint32_t depthRange[2]);
+    void     codeIntraLumaQT(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, bool bAllowSplit, bool bUseCachedIntraData, const IntraLumaQTCache* fullResult, Cost& costs, const uint32_t depthRange[2]);
     void     codeIntraLumaTSkip(Mode& mode, const CUGeom& cuGeom, uint32_t tuDepth, uint32_t absPartIdx, bool bUseCachedIntraData, Cost& costs);
     void     extractIntraResultQT(CUData& cu, Yuv& reconYuv, uint32_t tuDepth, uint32_t absPartIdx);
 


### PR DESCRIPTION
Reference samples and RDOQ bit estimates do not change while the encoder evaluates luma modes for one PU.

- Prepare unfiltered and filtered reference samples during rough mode selection.
- Prepare the root TU RDOQ bit estimates once from the saved entropy context.
- Reuse both inputs for candidate RDO and best-mode measurement.
- Continue preparing data for each child TU during recursive evaluation.
- Reuse the best non-split TU cost, CBF state, entropy context, and reconstruction during final split-enabled measurement when it remains optimal.
