### PR TITLE
entropy: Inline bin cost estimation

### DIFF
--- a/source/encoder/entropy.cpp
+++ b/source/encoder/entropy.cpp
@@ -2864,18 +2864,8 @@ void Entropy::resetBits()
 }
 
 /** Encode bin */
-void Entropy::encodeBin(uint32_t binValue, uint8_t &ctxModel)
+void Entropy::writeBin(uint32_t binValue, uint32_t mstate)
 {
-    uint32_t mstate = ctxModel;
-
-    ctxModel = sbacNext(mstate, binValue);
-
-    if (!m_bitIf)
-    {
-        m_fracBits += sbacGetEntropyBits(mstate, binValue);
-        return;
-    }
-
     uint32_t range = m_range;
     uint32_t state = sbacGetState(mstate);
     uint32_t lps = g_lpsTable[state][((uint8_t)range >> 6)];

--- a/source/encoder/entropy.h
+++ b/source/encoder/entropy.h
@@ -216,7 +216,16 @@ private:
     void start();
     void finish();
 
-    void encodeBin(uint32_t binValue, uint8_t& ctxModel);
+    void encodeBin(uint32_t binValue, uint8_t& ctxModel)
+    {
+        uint32_t mstate = ctxModel;
+        ctxModel = sbacNext(mstate, binValue);
+        if (!m_bitIf)
+            m_fracBits += sbacGetEntropyBits(mstate, binValue);
+        else
+            writeBin(binValue, mstate);
+    }
+    void writeBin(uint32_t binValue, uint32_t mstate);
     void encodeBinEP(uint32_t binValue);
     void encodeBinsEP(uint32_t binValues, int numBins);
     void encodeBinTrm(uint32_t binValue);


### PR DESCRIPTION
Reduce the overhead of CABAC bit estimation:

- Inline the context-state update and fractional-bit cost path used during mode search.
- Keep arithmetic bitstream coding in a separate helper.
