### PR TITLE
x265-Not found using pkg config

### DIFF
--- a/source/x265.h
+++ b/source/x265.h
@@ -25,6 +25,7 @@
 #ifndef X265_H
 #define X265_H
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include "x265_config.h"


### PR DESCRIPTION
## Description

Include `<stdbool.h>` in `source/x265.h` to provide the definition of the `bool`, `true`, and `false` types/macros when the header is used from C code.

This fixes the issue where `x265.h` is not self-contained when compiled with C compilers or when detected through `pkg-config`, resulting in errors such as `x265: Not found` or failures while compiling applications that include the x265 header.

## Changes

* Added `#include <stdbool.h>` to `source/x265.h`.
* No functional changes to the encoder.
* No performance impact expected.

## Testing

* Verified that the patch applies cleanly.
* Successfully built and committed the change.
* Working tree is clean after the change.

## Related Issue

Fixes: x265 - Not found using pkg-config
