### PR TITLE
Errors using intel compiler

### DIFF
--- a/source/common/x86/asm-primitives.cpp
+++ b/source/common/x86/asm-primitives.cpp
@@ -5484,7 +5484,7 @@ int __intel_cpu_indicator = 0;
 // CPU dispatcher function
 void PFX(intel_cpu_indicator_init)(void)
 {
-    uint32_t cpu = x265::cpu_detect(false);
+    uint32_t cpu = X265_NS::cpu_detect(false);
 
     if (cpu & X265_CPU_AVX)
         __intel_cpu_indicator = 0x20000;
@@ -5511,7 +5511,7 @@ void PFX(intel_cpu_indicator_init)(void)
  * that backs up all the registers. */
 void __intel_cpu_indicator_init(void)
 {
-    x265_safe_intel_cpu_indicator_init();
+    PFX(safe_intel_cpu_indicator_init)();
 }
 
 #else // ifdef __INTEL_COMPILER

--- a/source/x265.h
+++ b/source/x265.h
@@ -25,6 +25,7 @@
 #ifndef X265_H
 #define X265_H
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include "x265_config.h"


### PR DESCRIPTION
**Description**
Fix build issues in the x86 assembly primitives caused by incorrect namespace and symbol prefix handling.

**Changes**
Use X265_NS::cpu_detect(false) instead of x265::cpu_detect(false) to correctly reference the x265 namespace across the affected build configurations.

Fix the call to safe_intel_cpu_indicator_init() by using the PFX() macro:

PFX(safe_intel_cpu_indicator_init)();

instead of:

x265_safe_intel_cpu_indicator_init();